### PR TITLE
fix: Include typesversions for (hopefully) easier import statements

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,19 @@
     "./types": "./dist/types/index.js",
     "./enum": "./dist/enum/index.js"
   },
+  "typesVersions": {
+    "*": {
+      ".": [
+        "dist/index.d.ts"
+      ],
+      "types": [
+        "dist/types/index.d.ts"
+      ],
+      "enum": [
+        "dist/enum/index.d.ts"
+      ]
+    }
+  },
   "types": "dist/index.d.ts",
   "private": false,
   "scripts": {


### PR DESCRIPTION
Attempting to avoid imports for commonjs and ECMAScript (non-node clients) having a /dist/ explicitly in the path.