### PR TITLE
ci: direct semver-action to fail with warn instead of error in pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           token: ${{ github.token }}
           branch: main
+          noNewCommitBehavior: warn
 
       - name: Skip Deploy if No Version Bump
         if: ${{ steps.semver.outputs.next == '' }}


### PR DESCRIPTION
the default behaviour when no new version is detected is error, but we want to fail gracefully so switching to warn