### PR TITLE
feat: Make sure `validate` and `runAxleCalculations` can both return same shape data 

### DIFF
--- a/src/_test/unit/stow-validation.spec.ts
+++ b/src/_test/unit/stow-validation.spec.ts
@@ -3,6 +3,7 @@ import currentConfig from '../policy-config/_current-config.json';
 import testStow from '../permit-app/test-stow.json';
 import dayjs from 'dayjs';
 import { PermitAppInfo } from '../../enum/permit-app-info';
+import { PolicyCheckResultType } from '../../enum';
 
 describe('Single Trip Overweight Policy Configuration Validator', () => {
   const policy: Policy = new Policy(currentConfig);
@@ -130,6 +131,26 @@ describe('Single Trip Overweight Policy Configuration Validator', () => {
     return permit;
   };
 
+  const getAxleValidationViolation = (validationResult: any) =>
+    validationResult.violations.find(
+      (violation: any) =>
+        violation.message ===
+        'Vehicle configuration failed axle calculation policy checks',
+    );
+
+  const getRunAxleCalculationInputs = (permit: any) => {
+    const vehicleConfiguration = policy.getSimplifiedVehicleConfiguration(
+      permit.permitData.vehicleDetails,
+      permit.permitData.vehicleConfiguration,
+    );
+    const axleConfiguration = policy.combineAxleConfigurations(
+      permit.permitData.vehicleConfiguration.axleConfiguration,
+      permit.permitData.vehicleConfiguration.trailers ?? [],
+    );
+
+    return { vehicleConfiguration, axleConfiguration };
+  };
+
   it('should validate STOW successfully', async () => {
     const permit = getDatedPermit();
 
@@ -172,9 +193,62 @@ describe('Single Trip Overweight Policy Configuration Validator', () => {
   it('should validate submitted STOW evaluation failure payload', async () => {
     const permit = JSON.parse(JSON.stringify(evaluationFailurePermit));
 
-    await expect(policy.validate(permit)).rejects.toThrow(
-      'Missing weight dimensions',
+    const validationResult = await policy.validate(permit);
+
+    expect({
+      violations: validationResult.violations,
+      warnings: validationResult.warnings,
+      requirements: validationResult.requirements,
+      information: validationResult.information,
+    }).toMatchSnapshot();
+  });
+
+  it('should return a failed axle calculation result when a policy check cannot be evaluated', () => {
+    const permit = JSON.parse(JSON.stringify(evaluationFailurePermit));
+    const { vehicleConfiguration, axleConfiguration } =
+      getRunAxleCalculationInputs(permit);
+
+    const axleCalcResults = policy.runAxleCalculation(
+      vehicleConfiguration,
+      axleConfiguration,
+      permit.permitData.vehicleDetails.licensedGVW,
     );
+
+    expect(axleConfiguration).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ vehicleIndex: 0 }),
+        expect.objectContaining({ vehicleIndex: 1 }),
+      ]),
+    );
+    expect(axleCalcResults.results).toContainEqual(
+      expect.objectContaining({
+        result: PolicyCheckResultType.Fail,
+        message:
+          'check-permittable-weight could not be evaluated: Missing weight dimensions for Expando Semi-Trailers trailer axle count 1',
+      }),
+    );
+  });
+
+  it('should match validate axle violation details to runAxleCalculation failed results', async () => {
+    const permit = JSON.parse(JSON.stringify(evaluationFailurePermit));
+    const { vehicleConfiguration, axleConfiguration } =
+      getRunAxleCalculationInputs(permit);
+
+    const axleCalcResults = policy.runAxleCalculation(
+      vehicleConfiguration,
+      axleConfiguration,
+      permit.permitData.vehicleDetails.licensedGVW,
+    );
+    const validationResult = await policy.validate(permit);
+
+    const failedAxleCalcMessages = axleCalcResults.results
+      .filter((result) => result.result === PolicyCheckResultType.Fail)
+      .map((result) => result.message);
+    const axleValidationViolation =
+      getAxleValidationViolation(validationResult);
+
+    expect(axleValidationViolation).toBeDefined();
+    expect(axleValidationViolation.details).toEqual(failedAxleCalcMessages);
   });
 
   it('should validate submitted STOW evaluation failure payload differently without trailers', async () => {

--- a/src/_test/unit/stow-validation.spec.ts
+++ b/src/_test/unit/stow-validation.spec.ts
@@ -6,6 +6,121 @@ import { PermitAppInfo } from '../../enum/permit-app-info';
 
 describe('Single Trip Overweight Policy Configuration Validator', () => {
   const policy: Policy = new Policy(currentConfig);
+  const evaluationFailurePermit = {
+    permitType: 'STOW',
+    comment: '',
+    permitData: {
+      companyName: 'Parisian LLC Trucking',
+      doingBusinessAs: '',
+      clientNumber: 'B3-000005-722',
+      contactDetails: {
+        firstName: 'Red',
+        lastName: 'Stevenson',
+        phone1: '778-555-2907',
+        phone1Extension: '',
+        phone2: '778-555-2447',
+        phone2Extension: '',
+        email: 'noreply@gov.bc.ca',
+        additionalEmail: 'noreply@gov.bc.ca',
+      },
+      mailingAddress: {
+        addressLine1: '415 Schiller Road',
+        addressLine2: '',
+        city: 'Ballylinan',
+        provinceCode: 'BC',
+        countryCode: 'CA',
+        postalCode: 'B4P 1O2',
+      },
+      permitDuration: 1,
+      commodities: [
+        {
+          description: 'Permit Scope and Limitation',
+          condition: 'CVSE-1070',
+          conditionLink:
+            'https://www.th.gov.bc.ca/forms/getForm.aspx?formId=1261',
+          checked: true,
+          disabled: true,
+        },
+      ],
+      feeSummary: '',
+      loas: [],
+      applicationNotes: '',
+      permittedCommodity: {
+        commodityType: 'EMPTYXX',
+        loadDescription: 'NA',
+      },
+      thirdPartyLiability: null,
+      conditionalLicensingFee: null,
+      startDate: '2026-05-12',
+      expiryDate: '2026-05-12',
+      vehicleDetails: {
+        vin: '123456',
+        plate: 'ABC123',
+        make: 'Volvo',
+        year: 2020,
+        countryCode: 'CA',
+        provinceCode: 'BC',
+        vehicleType: 'powerUnit',
+        vehicleSubType: 'PICKRTT',
+        saveVehicle: false,
+        unitNumber: '',
+        vehicleId: '',
+        licensedGVW: 20000,
+      },
+      vehicleConfiguration: {
+        trailers: [
+          {
+            vehicleSubType: 'EXPANDO',
+            axleConfiguration: [
+              {
+                numberOfAxles: 1,
+                numberOfTires: 1,
+                tireSize: 279,
+                axleSpread: null,
+                axleUnitWeight: 5000,
+                interaxleSpacing: 200,
+              },
+            ],
+          },
+        ],
+        frontProjection: null,
+        rearProjection: null,
+        overallWidth: null,
+        overallHeight: null,
+        overallLength: null,
+        loadedGVW: null,
+        netWeight: null,
+        axleConfiguration: [
+          {
+            numberOfAxles: 2,
+            numberOfTires: 1,
+            tireSize: 279,
+            axleSpread: 256,
+            axleUnitWeight: 5000,
+            interaxleSpacing: null,
+          },
+          {
+            numberOfAxles: 2,
+            numberOfTires: 1,
+            tireSize: 330,
+            axleSpread: 200,
+            axleUnitWeight: 5000,
+            interaxleSpacing: 200,
+          },
+        ],
+      },
+      permittedRoute: {
+        manualRoute: {
+          origin: 'A',
+          destination: 'B',
+          highwaySequence: [],
+          exitPoint: null,
+          totalDistance: 1000,
+        },
+        routeDetails: 'A to B',
+      },
+    },
+  };
 
   const getDatedPermit = () => {
     const permit = JSON.parse(JSON.stringify(testStow));
@@ -52,5 +167,27 @@ describe('Single Trip Overweight Policy Configuration Validator', () => {
     expect(validationResult.violations[0].details).toContain(
       'No. of Axles for Axle Unit 2 is not permittable.',
     );
+  });
+
+  it('should validate submitted STOW evaluation failure payload', async () => {
+    const permit = JSON.parse(JSON.stringify(evaluationFailurePermit));
+
+    await expect(policy.validate(permit)).rejects.toThrow(
+      'Missing weight dimensions',
+    );
+  });
+
+  it('should validate submitted STOW evaluation failure payload differently without trailers', async () => {
+    const permit = JSON.parse(JSON.stringify(evaluationFailurePermit));
+    delete permit.permitData.vehicleConfiguration.trailers;
+
+    const validationResult = await policy.validate(permit);
+
+    expect({
+      violations: validationResult.violations,
+      warnings: validationResult.warnings,
+      requirements: validationResult.requirements,
+      information: validationResult.information,
+    }).toMatchSnapshot();
   });
 });

--- a/src/helper/facts.helper.ts
+++ b/src/helper/facts.helper.ts
@@ -41,7 +41,6 @@ async function getNormalizedAxleConfiguration(
 
   return policy.combineAxleConfigurations(axleConfiguration, trailers);
 }
-
 /**
  * Adds runtime facts for the validation. For example, adds the
  * validation date for comparison against startDate of the permit.
@@ -106,11 +105,12 @@ export function addRuntimeFacts(engine: Engine, policy: Policy): void {
           {},
           PermitAppInfo.PowerUnitType,
         );
-        const trailerList: Array<any> = await almanac.factValue(
-          PermitAppInfo.PermitData,
-          {},
-          PermitAppInfo.TrailerList,
-        );
+        const trailerList: Array<any> =
+          (await almanac.factValue(
+            PermitAppInfo.PermitData,
+            {},
+            PermitAppInfo.TrailerList,
+          )) ?? [];
         let fullVehicleConfiguration = [];
         fullVehicleConfiguration.push(powerUnit);
         fullVehicleConfiguration = fullVehicleConfiguration.concat(

--- a/src/helper/facts.helper.ts
+++ b/src/helper/facts.helper.ts
@@ -19,6 +19,29 @@ import { policyCheckMap } from './policy-check.helper';
 
 dayjs.extend(quarterOfYear);
 
+async function getNormalizedAxleConfiguration(
+  almanac: any,
+  policy: Policy,
+): Promise<Array<AxleConfiguration>> {
+  const permitVehicleConfiguration: VehicleConfiguration =
+    await almanac.factValue(
+      PermitAppInfo.PermitData,
+      {},
+      PermitAppInfo.VehicleConfiguration,
+    );
+  const axleConfiguration = permitVehicleConfiguration?.axleConfiguration ?? [];
+  const trailers = permitVehicleConfiguration?.trailers ?? [];
+  const hasNestedTrailerAxles = trailers.some(
+    (trailer) => (trailer.axleConfiguration?.length ?? 0) > 0,
+  );
+
+  if (!hasNestedTrailerAxles) {
+    return axleConfiguration;
+  }
+
+  return policy.combineAxleConfigurations(axleConfiguration, trailers);
+}
+
 /**
  * Adds runtime facts for the validation. For example, adds the
  * validation date for comparison against startDate of the permit.
@@ -187,13 +210,10 @@ export function addRuntimeFacts(engine: Engine, policy: Policy): void {
   engine.addFact(
     PolicyFacts.GrossVehicleCombinationWeight,
     async function (params, almanac) {
-      // Retrieve the axle configuration from permit data
-      const axleConfiguration: Array<AxleConfiguration> =
-        await almanac.factValue(
-          PermitAppInfo.PermitData,
-          {},
-          PermitAppInfo.AxleConfiguration,
-        );
+      const axleConfiguration = await getNormalizedAxleConfiguration(
+        almanac,
+        policy,
+      );
       return axleConfiguration.reduce((w, curr) => w + curr.axleUnitWeight, 0);
     },
   );
@@ -210,13 +230,10 @@ export function addRuntimeFacts(engine: Engine, policy: Policy): void {
       const vehicleConfiguration: Array<string> = await almanac.factValue(
         PolicyFacts.VehicleConfiguration,
       );
-      // Retrieve the axle configuration from permit data
-      const axleConfiguration: Array<AxleConfiguration> =
-        await almanac.factValue(
-          PermitAppInfo.PermitData,
-          {},
-          PermitAppInfo.AxleConfiguration,
-        );
+      const axleConfiguration = await getNormalizedAxleConfiguration(
+        almanac,
+        policy,
+      );
       // Get the specific policy check ID from parameters
       const policyCheckId = params.policyId;
 
@@ -256,13 +273,10 @@ export function addRuntimeFacts(engine: Engine, policy: Policy): void {
       const vehicleConfiguration: Array<string> = await almanac.factValue(
         PolicyFacts.VehicleConfiguration,
       );
-      // Retrieve the axle configuration from permit data
-      const axleConfiguration: Array<AxleConfiguration> =
-        await almanac.factValue(
-          PermitAppInfo.PermitData,
-          {},
-          PermitAppInfo.AxleConfiguration,
-        );
+      const axleConfiguration = await getNormalizedAxleConfiguration(
+        almanac,
+        policy,
+      );
       // Retrieve licensed GVW from permit data
       const vehicleDetails: PermitVehicleDetails = await almanac.factValue(
         PermitAppInfo.PermitData,

--- a/src/helper/policy-check.helper.ts
+++ b/src/helper/policy-check.helper.ts
@@ -33,6 +33,31 @@ type PolicyCheck = (
   axleConfiguration: Array<AxleConfiguration>,
 ) => Array<PolicyCheckResult>;
 
+export class PolicyCheckCannotEvaluateError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PolicyCheckCannotEvaluateError';
+  }
+}
+
+function assertWeightDimensions(
+  policy: Policy,
+  weight: Array<WeightDimension>,
+  vehicleType: string,
+  axles: number,
+  isPowerUnit: boolean,
+): void {
+  if (weight.length > 0) {
+    return;
+  }
+
+  const vehicleName =
+    policy.getVehicleDefinition(vehicleType)?.name ?? vehicleType;
+  throw new PolicyCheckCannotEvaluateError(
+    `Missing weight dimensions for ${vehicleName} ${isPowerUnit ? 'power unit axle code' : 'trailer axle count'} ${axles}`,
+  );
+}
+
 /**
  * Validates the number of axles in each axle unit.
  *
@@ -256,6 +281,7 @@ export function CheckPermittableWeight(
         axleConfiguration[1].numberOfAxles;
 
       weight = policy.getDefaultPowerUnitWeight(vc, powerUnitAxles);
+      assertWeightDimensions(policy, weight, vc, powerUnitAxles, true);
       const steerAxleDimension =
         policy.selectCorrectWeightDimension(
           weight,
@@ -280,6 +306,13 @@ export function CheckPermittableWeight(
         weight = policy.getDefaultTrailerWeight(
           vc,
           axleConfiguration[i + 1].numberOfAxles,
+        );
+        assertWeightDimensions(
+          policy,
+          weight,
+          vc,
+          axleConfiguration[i + 1].numberOfAxles,
+          false,
         );
         const trailerDimension =
           policy.selectCorrectWeightDimension(

--- a/src/policy-engine.ts
+++ b/src/policy-engine.ts
@@ -66,6 +66,7 @@ import {
 import { getVehicleDisplayCodeHelper } from './helper/display-code-helper';
 import {
   CheckNumberOfAxles,
+  PolicyCheckCannotEvaluateError,
   policyCheckMap,
 } from './helper/policy-check.helper';
 
@@ -1031,11 +1032,25 @@ export class Policy {
         continue;
       }
 
-      axleCalcResults.results.push(
-        ...policyCheck(this, vehicleConfiguration, axleConfiguration).map(
-          toAxleGroupPolicyCheckResult,
-        ),
-      );
+      try {
+        axleCalcResults.results.push(
+          ...policyCheck(this, vehicleConfiguration, axleConfiguration).map(
+            toAxleGroupPolicyCheckResult,
+          ),
+        );
+      } catch (e) {
+        if (!(e instanceof PolicyCheckCannotEvaluateError)) {
+          throw e;
+        }
+
+        axleCalcResults.results.push(
+          toAxleGroupPolicyCheckResult({
+            id: policyCheckId as PolicyCheckId,
+            result: PolicyCheckResultType.Fail,
+            message: `${policyCheckId} could not be evaluated: ${e.message}`,
+          }),
+        );
+      }
     }
     return axleCalcResults;
   }


### PR DESCRIPTION
TODO:
- Get the `fieldReference` stuff working, so validate returns the identical fieldReference shape for the subset of ASW evals that overlap with `runAxleCalculations`