### PR TITLE
test: Add more unit tests for empty trailer, unable to replicate crash.

### DIFF
--- a/src/_test/unit/stow-validation.spec.ts
+++ b/src/_test/unit/stow-validation.spec.ts
@@ -1,8 +1,136 @@
-import { Policy } from 'onroute-policy-engine';
+import { Policy } from '../../policy-engine';
 import currentConfig from '../policy-config/_current-config.json';
 import testStow from '../permit-app/test-stow.json';
 import dayjs from 'dayjs';
 import { PermitAppInfo } from '../../enum/permit-app-info';
+
+const reportedTrailerCrashInput = {
+  currentFormData: {
+    permitType: 'STOW',
+    permitId: '35',
+    originalPermitId: '35',
+    applicationNumber: 'A2-00010029-791-A00',
+    permitNumber: '',
+    permitStatus: 'IN_PROGRESS',
+    permitData: {
+      companyName: 'Parisian LLC Trucking',
+      doingBusinessAs: '',
+      clientNumber: 'B3-000005-722',
+      contactDetails: {
+        firstName: 'Red',
+        lastName: 'Stevenson',
+        phone1: '778-555-2907',
+        phone1Extension: '',
+        phone2: '778-555-2447',
+        phone2Extension: '',
+        email: 'noreply@gov.bc.ca',
+        additionalEmail: 'noreply@gov.bc.ca',
+      },
+      mailingAddress: {
+        addressLine1: '415 Schiller Road',
+        addressLine2: '',
+        city: 'Ballylinan',
+        provinceCode: 'BC',
+        countryCode: 'CA',
+        postalCode: 'B4P 1O2',
+      },
+      startDate: '2026-05-14T07:00:00.000Z',
+      permitDuration: 1,
+      expiryDate: '2026-05-15T06:59:59.999Z',
+      commodities: [
+        {
+          description: 'Permit Scope and Limitation',
+          condition: 'CVSE-1070',
+          conditionLink:
+            'https://www.th.gov.bc.ca/forms/getForm.aspx?formId=1261',
+          checked: true,
+          disabled: true,
+        },
+      ],
+      vehicleDetails: {
+        vehicleId: '101',
+        unitNumber: 'LCV1',
+        vin: '657854',
+        plate: 'TTH199',
+        make: 'Western Star',
+        year: 2020,
+        countryCode: 'CA',
+        provinceCode: 'BC',
+        vehicleType: 'powerUnit',
+        vehicleSubType: 'CONCRET',
+        licensedGVW: 20000,
+        saveVehicle: false,
+      },
+      feeSummary: '',
+      loas: [],
+      permittedRoute: {
+        manualRoute: {
+          origin: 'Victoria, BC',
+          destination: 'Sooke, BC',
+          highwaySequence: ['1', '2', '3'],
+          exitPoint: null,
+          totalDistance: 1000,
+        },
+        routeDetails: 'A to B',
+      },
+      applicationNotes: '',
+      permittedCommodity: {
+        commodityType: 'XXXXXXX',
+        loadDescription: 'NA',
+      },
+      vehicleConfiguration: {
+        axleConfiguration: [
+          {
+            numberOfAxles: 1,
+            numberOfTires: 2,
+            tireSize: 279,
+            axleSpread: null,
+            axleUnitWeight: 5000,
+            interaxleSpacing: null,
+          },
+          {
+            interaxleSpacing: 2,
+          },
+          {
+            numberOfAxles: 1,
+            numberOfTires: 2,
+            tireSize: 279,
+            axleSpread: null,
+            axleUnitWeight: 5000,
+            interaxleSpacing: null,
+          },
+        ],
+        trailers: [
+          {
+            vehicleSubType: 'XXXXXXX',
+            axleConfiguration: null,
+          },
+          {
+            vehicleSubType: 'BOOSTER',
+            axleConfiguration: [
+              {
+                interaxleSpacing: 2,
+              },
+              {
+                numberOfAxles: 1,
+                numberOfTires: 2,
+                tireSize: 279,
+                axleSpread: null,
+                axleUnitWeight: 5000,
+                interaxleSpacing: null,
+              },
+            ],
+          },
+        ],
+        loadedGVW: null,
+        netWeight: null,
+      },
+      thirdPartyLiability: null,
+      conditionalLicensingFee: null,
+    },
+    comment: '',
+  },
+};
 
 describe('Single Trip Overweight Policy Configuration Validator', () => {
   const policy: Policy = new Policy(currentConfig);
@@ -14,6 +142,9 @@ describe('Single Trip Overweight Policy Configuration Validator', () => {
     );
     return permit;
   };
+
+  const getReportedPermit = () =>
+    JSON.parse(JSON.stringify(reportedTrailerCrashInput.currentFormData));
 
   it('should validate STOW successfully', async () => {
     const permit = getDatedPermit();
@@ -52,5 +183,66 @@ describe('Single Trip Overweight Policy Configuration Validator', () => {
     expect(validationResult.violations[0].details).toContain(
       'No. of Axles for Axle Unit 2 is not permittable.',
     );
+  })
+
+
+  // The below four tests were written to validate a reported error by Glen, but unfortunately
+  // I'm unable to replicate the error. I've added below tests to ensure we don't regress.
+  it('should not crash validating the reported STOW input with trailers', async () => {
+    const permit = getReportedPermit();
+
+    await expect(policy.validate(permit)).resolves.toMatchObject({
+      violations: expect.any(Array),
+    });
+  });
+
+  it('should not crash validating the reported STOW input without trailers', async () => {
+    const permit = getReportedPermit();
+    permit.permitData.vehicleConfiguration.trailers = [];
+
+    await expect(policy.validate(permit)).resolves.toMatchObject({
+      violations: expect.any(Array),
+    });
+  });
+
+  it('should not crash running axle calculation for the reported STOW input with trailers', () => {
+    const permit = getReportedPermit();
+    const vehicleConfiguration = policy.getSimplifiedVehicleConfiguration(
+      permit.permitData.vehicleDetails,
+      permit.permitData.vehicleConfiguration,
+    );
+    const axleConfiguration = policy.combineAxleConfigurations(
+      permit.permitData.vehicleConfiguration.axleConfiguration,
+      permit.permitData.vehicleConfiguration.trailers,
+    );
+
+    expect(() =>
+      policy.runAxleCalculation(
+        vehicleConfiguration,
+        axleConfiguration,
+        permit.permitData.vehicleDetails.licensedGVW,
+      ),
+    ).not.toThrow();
+  });
+
+  it('should not crash running axle calculation for the reported STOW input without trailers', () => {
+    const permit = getReportedPermit();
+    permit.permitData.vehicleConfiguration.trailers = [];
+    const vehicleConfiguration = policy.getSimplifiedVehicleConfiguration(
+      permit.permitData.vehicleDetails,
+      permit.permitData.vehicleConfiguration,
+    );
+    const axleConfiguration = policy.combineAxleConfigurations(
+      permit.permitData.vehicleConfiguration.axleConfiguration,
+      permit.permitData.vehicleConfiguration.trailers,
+    );
+
+    expect(() =>
+      policy.runAxleCalculation(
+        vehicleConfiguration,
+        axleConfiguration,
+        permit.permitData.vehicleDetails.licensedGVW,
+      ),
+    ).not.toThrow();
   });
 });


### PR DESCRIPTION
This is 1 of 2 errors Glen noted, and I wasn't able to replicate, and have spun out to it's own unit test PR.

The second error Glen noted I made progress on, then realized it was going to be similar to #97. So I've left that to be resolved in that PR where it can be handled holistically.