### PR TITLE
test: Add more tests for ORV2-5374 that's already done. 

### DIFF
--- a/src/_test/unit/axle-calc.spec.ts
+++ b/src/_test/unit/axle-calc.spec.ts
@@ -13,6 +13,7 @@ import {
 } from '../../types';
 import {
   CheckBoosterAxleLimit,
+  CheckMinDriveAxleWeight,
   CheckTruckTractorWheelbase,
 } from '../../helper/policy-check.helper';
 import dayjs from 'dayjs';
@@ -54,6 +55,199 @@ describe('Axle Calculation Functions', () => {
       getTruckTractorWheelbaseAxles(interaxleSpacing, axleSpread);
     return p;
   };
+
+  const getDriveAxleWeightAxles = (
+    gcvw: number,
+    driveAxleCount: number,
+    driveAxleWeight: number,
+  ): Array<AxleConfiguration> => [
+    {
+      numberOfAxles: 1,
+      axleUnitWeight: gcvw - driveAxleWeight,
+    },
+    {
+      numberOfAxles: driveAxleCount,
+      axleUnitWeight: driveAxleWeight,
+    },
+  ];
+
+  // ORV2-5374 examples and expected pass/fail states come from:
+  // onRouteBCSpecification/Applying for Permits/Single Trip Overweight/ASW Tridem Drive AU 20% of Actual GCVW.feature
+  describe('minimum drive axle weight policy check', () => {
+    const tandemPassExamples = [
+      {
+        gcvw: 100000,
+        driveAxleWeight: 20000,
+      },
+      {
+        gcvw: 100000,
+        driveAxleWeight: 20500,
+      },
+      {
+        gcvw: 130000,
+        driveAxleWeight: 23000,
+      },
+      {
+        gcvw: 150000,
+        driveAxleWeight: 23000,
+      },
+    ];
+
+    const tandemFailExamples = [
+      {
+        gcvw: 100000,
+        driveAxleWeight: 19999,
+      },
+      {
+        gcvw: 130000,
+        driveAxleWeight: 22999,
+      },
+      {
+        gcvw: 150000,
+        driveAxleWeight: 22999,
+      },
+      {
+        gcvw: 90000,
+        driveAxleWeight: 15000,
+      },
+    ];
+
+    const tridemPassExamples = [
+      {
+        gcvw: 100000,
+        driveAxleWeight: 20000,
+      },
+      {
+        gcvw: 100000,
+        driveAxleWeight: 20500,
+      },
+      {
+        gcvw: 150000,
+        driveAxleWeight: 28000,
+      },
+      {
+        gcvw: 160000,
+        driveAxleWeight: 28000,
+      },
+    ];
+
+    const tridemFailExamples = [
+      {
+        gcvw: 100000,
+        driveAxleWeight: 19999,
+      },
+      {
+        gcvw: 150000,
+        driveAxleWeight: 27999,
+      },
+      {
+        gcvw: 160000,
+        driveAxleWeight: 27999,
+      },
+      {
+        gcvw: 90000,
+        driveAxleWeight: 15000,
+      },
+    ];
+
+    const expectMinDriveAxleWeightResult = (
+      gcvw: number,
+      driveAxleCount: number,
+      driveAxleWeight: number,
+      expectedResult: PolicyCheckResultType,
+    ) => {
+      const [result] = CheckMinDriveAxleWeight(
+        policy,
+        vehicleConfiguration,
+        getDriveAxleWeightAxles(gcvw, driveAxleCount, driveAxleWeight),
+      );
+
+      expect(result).toMatchObject({
+        id: PolicyCheckId.MinDriveAxleWeight,
+        result: expectedResult,
+      });
+    };
+
+    describe('tandem drive axle unit meets threshold', () => {
+      it.each(tandemPassExamples)(
+        'passes for GCVW $gcvw kg and drive axle weight $driveAxleWeight kg',
+        ({ gcvw, driveAxleWeight }) => {
+          expectMinDriveAxleWeightResult(
+            gcvw,
+            2,
+            driveAxleWeight,
+            PolicyCheckResultType.Pass,
+          );
+        },
+      );
+    });
+
+    describe('tandem drive axle unit is below threshold', () => {
+      it.each(tandemFailExamples)(
+        'fails for GCVW $gcvw kg and drive axle weight $driveAxleWeight kg',
+        ({ gcvw, driveAxleWeight }) => {
+          expectMinDriveAxleWeightResult(
+            gcvw,
+            2,
+            driveAxleWeight,
+            PolicyCheckResultType.Fail,
+          );
+        },
+      );
+    });
+
+    describe('tridem drive axle unit meets threshold', () => {
+      it.each(tridemPassExamples)(
+        'passes for GCVW $gcvw kg and drive axle weight $driveAxleWeight kg',
+        ({ gcvw, driveAxleWeight }) => {
+          expectMinDriveAxleWeightResult(
+            gcvw,
+            3,
+            driveAxleWeight,
+            PolicyCheckResultType.Pass,
+          );
+        },
+      );
+    });
+
+    describe('tridem drive axle unit is below threshold', () => {
+      it.each(tridemFailExamples)(
+        'fails for GCVW $gcvw kg and drive axle weight $driveAxleWeight kg',
+        ({ gcvw, driveAxleWeight }) => {
+          expectMinDriveAxleWeightResult(
+            gcvw,
+            3,
+            driveAxleWeight,
+            PolicyCheckResultType.Fail,
+          );
+        },
+      );
+    });
+
+    it('preserves the existing full axle configuration target range', () => {
+      const [result] = CheckMinDriveAxleWeight(policy, vehicleConfiguration, [
+        {
+          numberOfAxles: 1,
+          axleUnitWeight: 60000,
+        },
+        {
+          numberOfAxles: 2,
+          axleUnitWeight: 19999,
+        },
+        {
+          numberOfAxles: 3,
+          axleUnitWeight: 20001,
+        },
+      ]);
+
+      expect(result).toMatchObject({
+        id: PolicyCheckId.MinDriveAxleWeight,
+        result: PolicyCheckResultType.Fail,
+        startAxleUnit: 1,
+        endAxleUnit: 3,
+      });
+    });
+  });
 
   it('should return no failing policy checks for valid STOW', async () => {
     const results = policy.runAxleCalculation(

--- a/src/helper/policy-check.helper.ts
+++ b/src/helper/policy-check.helper.ts
@@ -444,9 +444,9 @@ export function CheckMinSteerAxleWeight(
  * Validates minimum drive axle weight requirements for tandem and tridem drive power units.
  *
  * This function checks that the drive axle meets minimum weight requirements based on the
- * Gross Vehicle Combination Weight (GVCW). For tandem drive axles, the minimum is 20% of GVCW
- * or 23,000 lbs (whichever is smaller). For tridem drive axles, the minimum is 20% of GVCW
- * or 28,000 lbs (whichever is smaller).
+ * Gross Combined Vehicle Weight (GCVW). For tandem drive axles, the minimum is 20% of GCVW
+ * or 23,000 kg (whichever is smaller). For tridem drive axles, the minimum is 20% of GCVW
+ * or 28,000 kg (whichever is smaller).
  *
  * @param _policy - The policy instance (unused in this check, but required by PolicyCheck type)
  * @param _vehicleConfiguration - Vehicle configuration (unused in this check, but required by PolicyCheck type)
@@ -454,12 +454,12 @@ export function CheckMinSteerAxleWeight(
  * @returns Array of AxleGroupPolicyCheckResult objects with validation results
  *
  * @example
- * // For a tandem drive configuration with GVCW of 120,000 kgs
+ * // For a tandem drive configuration with GCVW of 120,000 kg
  * const results = CheckMinDriveAxleWeight(policy, ['TRKTRAC'], [
  *   { numberOfAxles: 1, axleUnitWeight: 12000 },  // Steer axle
  *   { numberOfAxles: 2, axleUnitWeight: 24000 }   // Tandem drive axle
  * ]);
- * // Returns pass if drive axle weight >= min(20% of GVCW, 23,000 kgs)
+ * // Returns pass if drive axle weight >= min(20% of GCVW, 23,000 kg)
  *
  * @see PolicyCheck
  * @see AxleGroupPolicyCheckResult


### PR DESCRIPTION
Also updated JSDOC (but not code!) for relevant functions (fixing "lb" label to "kg").

There was a story for this, but it seems like it was basically done earlier by John Fletcher. When reviewing, I found the JSDocs incorrectly was talking about weights in lbs, but the weights should be in kg. This was no logic change and just a lable mistake. The actual values were the same (eg 23000 lbs was actually 23000 kg, not converting), and on top of that the actual variables in the function say they use kg, it was just the JSDoc that mistakenly said lb.

In addition, I added some more unit tests. All unit tests are based on the values in the spec file here: https://github.com/bcgov/onRouteBCSpecification/blob/main/Applying%20for%20Permits/Single%20Trip%20Overweight/ASW%20Tridem%20Drive%20AU%2020%25%20of%20Actual%20GCVW.feature

So, tl;dr - this eval was already done and working and I just added some unit tests.