### PR TITLE
feat: Steer and Drive Axle Unit Number of Wheels Changes

### DIFF
--- a/docs/policy-check-rules.md
+++ b/docs/policy-check-rules.md
@@ -23,14 +23,16 @@ The policy engine performs several validation checks on vehicle configurations t
 
 **What it does:** Ensures each axle unit has a valid number of tires.
 
-**How it works:** Each axle must have either 2, 4, or 8 tires per axle. This rule multiplies the number of axles by these valid tire counts.
+**How it works:** Axle unit 1 is treated as the steer axle unit, axle unit 2 is treated as the drive axle unit, and axle units 3+ use the generic axle unit allowance.
 
 **What it checks:**
-- For each axle unit, calculates valid tire counts: (number of axles × 2), (number of axles × 4), or (number of axles × 8)
+- For steer axle unit 1, valid tire counts are number of axles × 2
+- For drive axle unit 2, valid tire counts are number of axles × 2 or number of axles × 4
+- For axle units 3+, valid tire counts are number of axles × 2, number of axles × 4, or number of axles × 8
 - Validates that the actual tire count matches one of these calculations
 - Verifies that the applicant has not mis-entered the number of wheels
 
-**Example:** A 2-axle unit can have 4, 8, or 16 tires. A 3-axle unit can have 6, 12, or 24 tires.
+**Example:** A single steer axle unit can have 2 tires, a single drive axle unit can have 2 or 4 tires, and a single axle unit in position 3 or later can have 2, 4, or 8 tires.
 
 ## Rule 3: Permittable Weight Check
 

--- a/src/_test/unit/axle-calc.spec.ts
+++ b/src/_test/unit/axle-calc.spec.ts
@@ -13,6 +13,7 @@ import {
 } from '../../types';
 import {
   CheckBoosterAxleLimit,
+  CheckNumTiresPerAxle,
   CheckMinDriveAxleWeight,
   CheckTruckTractorWheelbase,
   CheckDriveJeepLoadEqualization,
@@ -71,6 +72,141 @@ describe('Axle Calculation Functions', () => {
       axleUnitWeight: driveAxleWeight,
     },
   ];
+
+  describe('number of wheels per axle unit policy check', () => {
+    type WheelCountCase = [number, number, number];
+
+    const getWheelCountAxles = (
+      axleUnit: number,
+      numberOfAxles: number,
+      numberOfTires: number,
+    ): Array<AxleConfiguration> =>
+      Array.from({ length: axleUnit }, (_, i) => ({
+        numberOfAxles: i + 1 === axleUnit ? numberOfAxles : 1,
+        axleUnitWeight: 5000,
+        numberOfTires: i + 1 === axleUnit ? numberOfTires : 2,
+        tireSize: 279,
+      }));
+
+    const expectWheelCountResult = (
+      axleUnit: number,
+      numberOfAxles: number,
+      numberOfTires: number,
+      expectedResult: PolicyCheckResultType,
+    ) => {
+      const results = CheckNumTiresPerAxle(
+        policy,
+        vehicleConfiguration,
+        getWheelCountAxles(axleUnit, numberOfAxles, numberOfTires),
+      );
+      const isPermittable =
+        expectedResult === PolicyCheckResultType.Pass
+          ? 'permittable'
+          : 'not permittable';
+
+      expect(results[axleUnit - 1]).toMatchObject({
+        id: PolicyCheckId.NumberOfWheelsPerAxle,
+        result: expectedResult,
+        message: `No. of Wheels for Axle Unit ${axleUnit} is ${isPermittable}.`,
+        startAxleUnit: axleUnit,
+        endAxleUnit: axleUnit,
+      });
+    };
+
+    // These are the explicit examples from:
+    // https://github.com/bcgov/onRouteBCSpecification/blob/main/Applying%20for%20Permits/Single%20Trip%20Overweight/ASW%20No.%20of%20Wheels%20per%20Axle.feature
+    // The struck example row `single | axleUnit 2 | wheels 6` is intentionally
+    // omitted because BA confirmed it was a table glitch.
+    const specPassExamples: Array<WheelCountCase> = [
+      [3, 1, 2],
+      [3, 1, 4],
+      [3, 1, 8],
+      [3, 2, 4],
+      [3, 2, 8],
+      [3, 2, 16],
+      [3, 3, 6],
+      [3, 3, 12],
+      [3, 3, 24],
+    ];
+
+    const specFailExamples: Array<WheelCountCase> = [
+      [1, 1, 4],
+      [2, 1, 8],
+      [3, 2, 10],
+      [4, 3, 8],
+    ];
+
+    it.each(specPassExamples)(
+      'passes explicit spec example for axle unit %i with %i axles and %i wheels',
+      (axleUnit, numberOfAxles, numberOfTires) => {
+        expectWheelCountResult(
+          axleUnit,
+          numberOfAxles,
+          numberOfTires,
+          PolicyCheckResultType.Pass,
+        );
+      },
+    );
+
+    it.each(specFailExamples)(
+      'fails explicit spec example for axle unit %i with %i axles and %i wheels',
+      (axleUnit, numberOfAxles, numberOfTires) => {
+        expectWheelCountResult(
+          axleUnit,
+          numberOfAxles,
+          numberOfTires,
+          PolicyCheckResultType.Fail,
+        );
+      },
+    );
+
+    // These cases are inferred from the rules rather than copied from example rows.
+    // They complete the steer/drive matrix:
+    // - steer unit 1 allows numberOfAxles * 2
+    // - drive unit 2 allows numberOfAxles * 2 or * 4
+    const ruleDerivedPassExamples: Array<WheelCountCase> = [
+      [1, 1, 2],
+      [1, 2, 4],
+      [1, 3, 6],
+      [2, 1, 2],
+      [2, 1, 4],
+      [2, 2, 4],
+      [2, 2, 8],
+      [2, 3, 6],
+      [2, 3, 12],
+    ];
+
+    const ruleDerivedFailExamples: Array<WheelCountCase> = [
+      [1, 2, 8],
+      [1, 3, 12],
+      [2, 2, 16],
+      [2, 3, 24],
+    ];
+
+    it.each(ruleDerivedPassExamples)(
+      'passes derived rule case for axle unit %i with %i axles and %i wheels',
+      (axleUnit, numberOfAxles, numberOfTires) => {
+        expectWheelCountResult(
+          axleUnit,
+          numberOfAxles,
+          numberOfTires,
+          PolicyCheckResultType.Pass,
+        );
+      },
+    );
+
+    it.each(ruleDerivedFailExamples)(
+      'fails derived rule case for axle unit %i with %i axles and %i wheels',
+      (axleUnit, numberOfAxles, numberOfTires) => {
+        expectWheelCountResult(
+          axleUnit,
+          numberOfAxles,
+          numberOfTires,
+          PolicyCheckResultType.Fail,
+        );
+      },
+    );
+  });
 
   // ORV2-5374 examples and expected pass/fail states come from:
   // onRouteBCSpecification/Applying for Permits/Single Trip Overweight/ASW Tridem Drive AU 20% of Actual GCVW.feature
@@ -293,6 +429,48 @@ describe('Axle Calculation Functions', () => {
       result: PolicyCheckResultType.Fail,
       startAxleUnit: 1,
       endAxleUnit: 1,
+    });
+  });
+
+  it('should fail axle calculation when steer axle unit has a drive-only wheel count', async () => {
+    const ac = JSON.parse(
+      JSON.stringify(axleConfiguration),
+    ) as Array<AxleConfiguration>;
+    ac[0].numberOfAxles = 1;
+    ac[0].numberOfTires = 4;
+
+    const results = policy.runAxleCalculation(vehicleConfiguration, ac, 0);
+    const numTiresResult = results.results.find(
+      (r) => r.id === PolicyCheckId.NumberOfWheelsPerAxle,
+    );
+
+    expect(numTiresResult).toMatchObject({
+      result: PolicyCheckResultType.Fail,
+      message: 'No. of Wheels for Axle Unit 1 is not permittable.',
+      startAxleUnit: 1,
+      endAxleUnit: 1,
+    });
+  });
+
+  it('should fail axle calculation when drive axle unit has a trailer-only wheel count', async () => {
+    const ac = JSON.parse(
+      JSON.stringify(axleConfiguration),
+    ) as Array<AxleConfiguration>;
+    ac[1].numberOfAxles = 1;
+    ac[1].numberOfTires = 8;
+
+    const results = policy.runAxleCalculation(vehicleConfiguration, ac, 0);
+    const numTiresResult = results.results.find(
+      (r) =>
+        r.id === PolicyCheckId.NumberOfWheelsPerAxle &&
+        r.startAxleUnit === 2,
+    );
+
+    expect(numTiresResult).toMatchObject({
+      result: PolicyCheckResultType.Fail,
+      message: 'No. of Wheels for Axle Unit 2 is not permittable.',
+      startAxleUnit: 2,
+      endAxleUnit: 2,
     });
   });
 

--- a/src/_test/unit/stow-validation.spec.ts
+++ b/src/_test/unit/stow-validation.spec.ts
@@ -197,6 +197,38 @@ describe('Single Trip Overweight Policy Configuration Validator', () => {
     );
   });
 
+  it('should raise STOW axle calculation violation when steer axle unit has an invalid wheel count', async () => {
+    const permit = getDatedPermit();
+    permit.permitData.vehicleConfiguration.axleConfiguration[0].numberOfAxles = 1;
+    permit.permitData.vehicleConfiguration.axleConfiguration[0].numberOfTires = 4;
+
+    const validationResult = await policy.validate(permit);
+
+    expect(validationResult.violations).toHaveLength(1);
+    expect(validationResult.violations[0].message).toBe(
+      'Vehicle configuration failed axle calculation policy checks',
+    );
+    expect(validationResult.violations[0].details).toContain(
+      'No. of Wheels for Axle Unit 1 is not permittable.',
+    );
+  });
+
+  it('should raise STOW axle calculation violation when drive axle unit has an invalid wheel count', async () => {
+    const permit = getDatedPermit();
+    permit.permitData.vehicleConfiguration.axleConfiguration[1].numberOfAxles = 1;
+    permit.permitData.vehicleConfiguration.axleConfiguration[1].numberOfTires = 8;
+
+    const validationResult = await policy.validate(permit);
+
+    expect(validationResult.violations).toHaveLength(1);
+    expect(validationResult.violations[0].message).toBe(
+      'Vehicle configuration failed axle calculation policy checks',
+    );
+    expect(validationResult.violations[0].details).toContain(
+      'No. of Wheels for Axle Unit 2 is not permittable.',
+    );
+  });
+
   it('should raise STOW axle calculation violation when truck tractor wheelbase exceeds 7.2m', async () => {
     const permit = getDatedPermit();
     setTruckTractorWheelbaseScenario(permit, 660, 140);

--- a/src/helper/policy-check.helper.ts
+++ b/src/helper/policy-check.helper.ts
@@ -136,9 +136,9 @@ export function CheckBridgeFormula(
  * Validates the number of tires per axle unit against regulatory requirements.
  *
  * This function checks that each axle unit has a valid number of tires based on
- * the number of axles in that unit. The validation allows for 2, 4, or 8 tires
- * per axle (2, 4, or 8 * number of axles). This ensures compliance with tire
- * count regulations for commercial vehicles.
+ * the number of axles in that unit and the axle unit position. Axle unit 1 is
+ * the steer axle unit, axle unit 2 is the drive axle unit, and axle units 3+
+ * use the generic axle unit allowance.
  *
  * @param _policy - The policy instance (unused in this check, but required by PolicyCheck type)
  * @param _vehicleConfiguration - Vehicle configuration (unused in this check, but required by PolicyCheck type)
@@ -148,15 +148,15 @@ export function CheckBridgeFormula(
  * @example
  * // For a vehicle with 2 axle units
  * const results = CheckNumTiresPerAxle(policy, ['TRKTRAC'], [
- *   { numberOfAxles: 2, numberOfTires: 4 },  // 2 axles × 2 tires = 4 (valid)
- *   { numberOfAxles: 3, numberOfTires: 12 }  // 3 axles × 4 tires = 12 (valid)
+ *   { numberOfAxles: 2, numberOfTires: 4 },  // tandem steer: 4 (valid)
+ *   { numberOfAxles: 3, numberOfTires: 12 }  // tridem drive: 12 (valid)
  * ]);
  * // Returns pass results for both axle units
  *
  * @example
  * // Invalid tire count example
  * const results = CheckNumTiresPerAxle(policy, ['TRKTRAC'], [
- *   { numberOfAxles: 2, numberOfTires: 6 }  // 2 axles × 3 tires = 6 (invalid - not 2, 4, or 8 per axle)
+ *   { numberOfAxles: 1, numberOfTires: 8 }  // single drive: 8 (invalid)
  * ]);
  * // Returns fail result for the axle unit
  *
@@ -182,9 +182,11 @@ export function CheckNumTiresPerAxle(
       // Invalid number of axles, cannot calculate
       message = `Number of axles for axle unit ${axleNum} is not permittable.`;
     } else {
-      const checkResult = [numAxles * 2, numAxles * 4, numAxles * 8].includes(
-        numTires,
-      );
+      const multipliers =
+        axleNum === 1 ? [2] : axleNum === 2 ? [2, 4] : [2, 4, 8];
+      const checkResult = multipliers
+        .map((multiplier) => numAxles * multiplier)
+        .includes(numTires);
       message = checkResult
         ? `No. of Wheels for Axle Unit ${axleNum} is permittable.`
         : `No. of Wheels for Axle Unit ${axleNum} is not permittable.`;


### PR DESCRIPTION
This is a relatively minor change to an existing eval, adding in some additional rules for number of wheels based on axle logic.

Because this is modifying an existing STOW eval, rather than a new one, all we need to do on the FE is bump package version. We do *not* need to also 'whitelist' the eval or anything like that to enable it as that was previously done.

[Spec file](https://github.com/bcgov/onRouteBCSpecification/blob/main/Applying%20for%20Permits/Single%20Trip%20Overweight/ASW%20No.%20of%20Wheels%20per%20Axle.feature)

Note: Line 93 of spec file (`| Invalid for single axle unit   | single   | 2        | 6      |`) was confirmed as a mistake and not in the solution or tests or anything, we just totally ignore that one line.