### PR TITLE
feat: ORV2-5366 and ORV2-5506: Add 27% and 40% in some PR

### DIFF
--- a/src/_test/unit/axle-calc.spec.ts
+++ b/src/_test/unit/axle-calc.spec.ts
@@ -15,6 +15,8 @@ import {
   CheckBoosterAxleLimit,
   CheckNumTiresPerAxle,
   CheckMinDriveAxleWeight,
+  CheckMinSteerAxleWeight,
+  CheckMinTandemSteerAxleWeight,
   CheckTruckTractorWheelbase,
   CheckDriveJeepLoadEqualization,
 } from '../../helper/policy-check.helper';
@@ -208,6 +210,265 @@ describe('Axle Calculation Functions', () => {
     );
   });
 
+  const getSteerDriveAxleWeightAxles = (
+    steerAxleCount: number,
+    driveAxleCount: number,
+    steerAxleWeight: number,
+    driveAxleWeight: number,
+  ): Array<AxleConfiguration> => [
+    {
+      numberOfAxles: steerAxleCount,
+      axleUnitWeight: steerAxleWeight,
+    },
+    {
+      numberOfAxles: driveAxleCount,
+      axleUnitWeight: driveAxleWeight,
+    },
+  ];
+
+  // ORV2-5366 is only for single steer axle units with tridem drive axle units.
+  describe('minimum single steer axle weight policy check', () => {
+    const passExamples = [
+      {
+        tridemDriveAxleWeight: 20000,
+        steerAxleWeight: 5400,
+      },
+      {
+        tridemDriveAxleWeight: 20000,
+        steerAxleWeight: 6000,
+      },
+      {
+        tridemDriveAxleWeight: 18000,
+        steerAxleWeight: 4860,
+      },
+    ];
+
+    const failExamples = [
+      {
+        tridemDriveAxleWeight: 20000,
+        steerAxleWeight: 5399,
+      },
+      {
+        tridemDriveAxleWeight: 18000,
+        steerAxleWeight: 4859,
+      },
+      {
+        tridemDriveAxleWeight: 15000,
+        steerAxleWeight: 4000,
+      },
+    ];
+
+    const expectMinSingleSteerAxleWeightResult = (
+      tridemDriveAxleWeight: number,
+      steerAxleWeight: number,
+      expectedResult: PolicyCheckResultType,
+    ) => {
+      const [result] = CheckMinSteerAxleWeight(
+        policy,
+        vehicleConfiguration,
+        getSteerDriveAxleWeightAxles(
+          1,
+          3,
+          steerAxleWeight,
+          tridemDriveAxleWeight,
+        ),
+      );
+
+      expect(result).toMatchObject({
+        id: PolicyCheckId.MinSteerAxleWeight,
+        result: expectedResult,
+        startAxleUnit: 1,
+        endAxleUnit: 2,
+      });
+    };
+
+    it.each(passExamples)(
+      'passes for tridem drive axle weight $tridemDriveAxleWeight kg and single steer axle weight $steerAxleWeight kg',
+      ({ tridemDriveAxleWeight, steerAxleWeight }) => {
+        expectMinSingleSteerAxleWeightResult(
+          tridemDriveAxleWeight,
+          steerAxleWeight,
+          PolicyCheckResultType.Pass,
+        );
+      },
+    );
+
+    it.each(failExamples)(
+      'fails for tridem drive axle weight $tridemDriveAxleWeight kg and single steer axle weight $steerAxleWeight kg',
+      ({ tridemDriveAxleWeight, steerAxleWeight }) => {
+        expectMinSingleSteerAxleWeightResult(
+          tridemDriveAxleWeight,
+          steerAxleWeight,
+          PolicyCheckResultType.Fail,
+        );
+      },
+    );
+
+    it('does not apply to tandem steer axle units', () => {
+      const [result] = CheckMinSteerAxleWeight(
+        policy,
+        vehicleConfiguration,
+        getSteerDriveAxleWeightAxles(2, 3, 4000, 20000),
+      );
+
+      expect(result).toMatchObject({
+        id: PolicyCheckId.MinSteerAxleWeight,
+        result: PolicyCheckResultType.Pass,
+        message: 'Policy check does not apply to this configuration',
+      });
+    });
+  });
+
+  // ORV2-5506 is only for tandem steer axle units with tandem or tridem drive axle units.
+  describe('minimum tandem steer axle weight policy check', () => {
+    const tandemDrivePassExamples = [
+      {
+        driveAxleWeight: 17000,
+        steerAxleWeight: 6800,
+      },
+      {
+        driveAxleWeight: 17000,
+        steerAxleWeight: 7000,
+      },
+      {
+        driveAxleWeight: 15000,
+        steerAxleWeight: 6000,
+      },
+    ];
+
+    const tandemDriveFailExamples = [
+      {
+        driveAxleWeight: 17000,
+        steerAxleWeight: 6799,
+      },
+      {
+        driveAxleWeight: 15000,
+        steerAxleWeight: 5999,
+      },
+      {
+        driveAxleWeight: 17000,
+        steerAxleWeight: 5000,
+      },
+    ];
+
+    const tridemDrivePassExamples = [
+      {
+        driveAxleWeight: 20000,
+        steerAxleWeight: 8000,
+      },
+      {
+        driveAxleWeight: 20000,
+        steerAxleWeight: 8500,
+      },
+      {
+        driveAxleWeight: 18000,
+        steerAxleWeight: 7200,
+      },
+    ];
+
+    const tridemDriveFailExamples = [
+      {
+        driveAxleWeight: 20000,
+        steerAxleWeight: 7999,
+      },
+      {
+        driveAxleWeight: 18000,
+        steerAxleWeight: 7199,
+      },
+      {
+        driveAxleWeight: 15000,
+        steerAxleWeight: 5000,
+      },
+    ];
+
+    const expectMinTandemSteerAxleWeightResult = (
+      driveAxleCount: number,
+      driveAxleWeight: number,
+      steerAxleWeight: number,
+      expectedResult: PolicyCheckResultType,
+    ) => {
+      const [result] = CheckMinTandemSteerAxleWeight(
+        policy,
+        vehicleConfiguration,
+        getSteerDriveAxleWeightAxles(
+          2,
+          driveAxleCount,
+          steerAxleWeight,
+          driveAxleWeight,
+        ),
+      );
+
+      expect(result).toMatchObject({
+        id: PolicyCheckId.MinTandemSteerAxleWeight,
+        result: expectedResult,
+        startAxleUnit: 1,
+        endAxleUnit: 2,
+      });
+    };
+
+    it.each(tandemDrivePassExamples)(
+      'passes for tandem drive axle weight $driveAxleWeight kg and tandem steer axle weight $steerAxleWeight kg',
+      ({ driveAxleWeight, steerAxleWeight }) => {
+        expectMinTandemSteerAxleWeightResult(
+          2,
+          driveAxleWeight,
+          steerAxleWeight,
+          PolicyCheckResultType.Pass,
+        );
+      },
+    );
+
+    it.each(tandemDriveFailExamples)(
+      'fails for tandem drive axle weight $driveAxleWeight kg and tandem steer axle weight $steerAxleWeight kg',
+      ({ driveAxleWeight, steerAxleWeight }) => {
+        expectMinTandemSteerAxleWeightResult(
+          2,
+          driveAxleWeight,
+          steerAxleWeight,
+          PolicyCheckResultType.Fail,
+        );
+      },
+    );
+
+    it.each(tridemDrivePassExamples)(
+      'passes for tridem drive axle weight $driveAxleWeight kg and tandem steer axle weight $steerAxleWeight kg',
+      ({ driveAxleWeight, steerAxleWeight }) => {
+        expectMinTandemSteerAxleWeightResult(
+          3,
+          driveAxleWeight,
+          steerAxleWeight,
+          PolicyCheckResultType.Pass,
+        );
+      },
+    );
+
+    it.each(tridemDriveFailExamples)(
+      'fails for tridem drive axle weight $driveAxleWeight kg and tandem steer axle weight $steerAxleWeight kg',
+      ({ driveAxleWeight, steerAxleWeight }) => {
+        expectMinTandemSteerAxleWeightResult(
+          3,
+          driveAxleWeight,
+          steerAxleWeight,
+          PolicyCheckResultType.Fail,
+        );
+      },
+    );
+
+    it('does not apply to single steer axle units', () => {
+      const [result] = CheckMinTandemSteerAxleWeight(
+        policy,
+        vehicleConfiguration,
+        getSteerDriveAxleWeightAxles(1, 3, 5000, 20000),
+      );
+
+      expect(result).toMatchObject({
+        id: PolicyCheckId.MinTandemSteerAxleWeight,
+        result: PolicyCheckResultType.Pass,
+        message: 'Policy check does not apply to this configuration',
+      });
+    });
+  });
+
   // ORV2-5374 examples and expected pass/fail states come from:
   // onRouteBCSpecification/Applying for Permits/Single Trip Overweight/ASW Tridem Drive AU 20% of Actual GCVW.feature
   describe('minimum drive axle weight policy check', () => {
@@ -397,6 +658,56 @@ describe('Axle Calculation Functions', () => {
     ).toBe(true);
   });
 
+  it('should include failed minimum single steer axle weight results from axle calculation', async () => {
+    const ac = JSON.parse(
+      JSON.stringify(axleConfiguration),
+    ) as Array<AxleConfiguration>;
+    ac[0].numberOfAxles = 1;
+    ac[0].axleUnitWeight = 5399;
+    ac[1].numberOfAxles = 3;
+    ac[1].numberOfTires = 12;
+    ac[1].axleUnitWeight = 20000;
+
+    const results = policy.runAxleCalculation(vehicleConfiguration, ac, 0);
+    const minSteerResult = results.results.find(
+      (r) => r.id === PolicyCheckId.MinSteerAxleWeight,
+    );
+
+    expect(minSteerResult).toMatchObject({
+      result: PolicyCheckResultType.Fail,
+      message:
+        'Single steer axle must be a minimum of 27% of tridem drive axle weight',
+      startAxleUnit: 1,
+      endAxleUnit: 2,
+    });
+  });
+
+  it('should include failed minimum tandem steer axle weight results from axle calculation', async () => {
+    const ac = JSON.parse(
+      JSON.stringify(axleConfiguration),
+    ) as Array<AxleConfiguration>;
+    ac[0].numberOfAxles = 2;
+    ac[0].numberOfTires = 4;
+    ac[0].axleSpread = 160;
+    ac[0].axleUnitWeight = 7999;
+    ac[1].numberOfAxles = 3;
+    ac[1].numberOfTires = 12;
+    ac[1].axleUnitWeight = 20000;
+
+    const results = policy.runAxleCalculation(vehicleConfiguration, ac, 0);
+    const minTandemSteerResult = results.results.find(
+      (r) => r.id === PolicyCheckId.MinTandemSteerAxleWeight,
+    );
+
+    expect(minTandemSteerResult).toMatchObject({
+      result: PolicyCheckResultType.Fail,
+      message:
+        'Tandem steer axle must be a minimum of 40% of drive axle weight',
+      startAxleUnit: 1,
+      endAxleUnit: 2,
+    });
+  });
+
   it('should fail policy check for invalid number of tires', async () => {
     const ac = JSON.parse(
       JSON.stringify(axleConfiguration),
@@ -462,8 +773,7 @@ describe('Axle Calculation Functions', () => {
     const results = policy.runAxleCalculation(vehicleConfiguration, ac, 0);
     const numTiresResult = results.results.find(
       (r) =>
-        r.id === PolicyCheckId.NumberOfWheelsPerAxle &&
-        r.startAxleUnit === 2,
+        r.id === PolicyCheckId.NumberOfWheelsPerAxle && r.startAxleUnit === 2,
     );
 
     expect(numTiresResult).toMatchObject({

--- a/src/_test/unit/stow-validation.spec.ts
+++ b/src/_test/unit/stow-validation.spec.ts
@@ -160,6 +160,31 @@ describe('Single Trip Overweight Policy Configuration Validator', () => {
       interaxleSpacing;
   };
 
+  const setMinimumSteerWeightScenario = (
+    permit: any,
+    steerAxleCount: number,
+    steerAxleTireCount: number,
+    steerAxleWeight: number,
+    driveAxleCount: number,
+    driveAxleTireCount: number,
+    driveAxleWeight: number,
+  ) => {
+    permit.permitData.vehicleConfiguration.axleConfiguration[0].numberOfAxles =
+      steerAxleCount;
+    permit.permitData.vehicleConfiguration.axleConfiguration[0].axleSpread =
+      steerAxleCount > 1 ? 160 : undefined;
+    permit.permitData.vehicleConfiguration.axleConfiguration[0].numberOfTires =
+      steerAxleTireCount;
+    permit.permitData.vehicleConfiguration.axleConfiguration[0].axleUnitWeight =
+      steerAxleWeight;
+    permit.permitData.vehicleConfiguration.axleConfiguration[1].numberOfAxles =
+      driveAxleCount;
+    permit.permitData.vehicleConfiguration.axleConfiguration[1].numberOfTires =
+      driveAxleTireCount;
+    permit.permitData.vehicleConfiguration.axleConfiguration[1].axleUnitWeight =
+      driveAxleWeight;
+  };
+
   it('should validate STOW successfully', async () => {
     const permit = getDatedPermit();
 
@@ -258,6 +283,36 @@ describe('Single Trip Overweight Policy Configuration Validator', () => {
       'Wheelbase for Axle Unit 1 and Axle Unit 2 is between 6.2m and 7.2m. See CTPM 5.3.7.A.',
     );
     expect(validationResult.warnings).toHaveLength(0);
+  });
+
+  it('should raise STOW axle calculation violation when single steer axle weight is below 27% of tridem drive axle weight', async () => {
+    const permit = getDatedPermit();
+    setMinimumSteerWeightScenario(permit, 1, 2, 5399, 3, 12, 20000);
+
+    const validationResult = await policy.validate(permit);
+
+    expect(validationResult.violations).toHaveLength(1);
+    expect(validationResult.violations[0].message).toBe(
+      'Vehicle configuration failed axle calculation policy checks',
+    );
+    expect(validationResult.violations[0].details).toContain(
+      'Single steer axle must be a minimum of 27% of tridem drive axle weight',
+    );
+  });
+
+  it('should raise STOW axle calculation violation when tandem steer axle weight is below 40% of tridem drive axle weight', async () => {
+    const permit = getDatedPermit();
+    setMinimumSteerWeightScenario(permit, 2, 4, 7999, 3, 12, 20000);
+
+    const validationResult = await policy.validate(permit);
+
+    expect(validationResult.violations).toHaveLength(1);
+    expect(validationResult.violations[0].message).toBe(
+      'Vehicle configuration failed axle calculation policy checks',
+    );
+    expect(validationResult.violations[0].details).toContain(
+      'Tandem steer axle must be a minimum of 40% of drive axle weight',
+    );
   });
 
   // =========================================================================
@@ -458,10 +513,8 @@ describe('Single Trip Overweight Policy Configuration Validator', () => {
 
   it('should raise STOW axle calculation violation when drive and jeep axle units are not load equalized', async () => {
     const permit = getDatedPermit();
-    permit.permitData.vehicleConfiguration.axleConfiguration[1].axleUnitWeight =
-      12000;
-    permit.permitData.vehicleConfiguration.axleConfiguration[2].axleUnitWeight =
-      10999;
+    permit.permitData.vehicleConfiguration.axleConfiguration[1].axleUnitWeight = 12000;
+    permit.permitData.vehicleConfiguration.axleConfiguration[2].axleUnitWeight = 10999;
 
     const validationResult = await policy.validate(permit);
 

--- a/src/enum/policy-check.ts
+++ b/src/enum/policy-check.ts
@@ -11,6 +11,7 @@ export enum PolicyCheckId {
   MaxTireLoad = 'max-tire-load',
   MinDriveAxleWeight = 'minimum-drive-axle-weight',
   MinSteerAxleWeight = 'minimum-steer-axle-weight',
+  MinTandemSteerAxleWeight = 'minimum-tandem-steer-axle-weight',
   NumberOfAxles = 'number-of-axles',
   NumberOfWheelsPerAxle = 'number-of-wheels',
   TruckTractorWheelbase = 'truck-tractor-wheelbase',

--- a/src/helper/policy-check.helper.ts
+++ b/src/helper/policy-check.helper.ts
@@ -34,6 +34,16 @@ type PolicyCheck = (
   axleConfiguration: Array<AxleConfiguration>,
 ) => Array<PolicyCheckResult>;
 
+function meetsMinimumSteerPercentageOfDriveAxleWeight(
+  steerAxle: AxleConfiguration,
+  driveAxle: AxleConfiguration,
+  minimumPercentage: number,
+): boolean {
+  return (
+    steerAxle.axleUnitWeight >= driveAxle.axleUnitWeight * minimumPercentage
+  );
+}
+
 /**
  * Validates the number of axles in each axle unit.
  *
@@ -393,7 +403,7 @@ export function CheckPermittableWeight(
  * @example
  * // For a single steer, tridem drive configuration
  * const results = CheckMinSteerAxleWeight(policy, ['TRKTRAC'], [
- *   { numberOfAxles: 1, axleUnitWeight: 8000 },  // Steer axle
+ *   { numberOfAxles: 1, axleUnitWeight: 8000 },  // Single steer axle
  *   { numberOfAxles: 3, axleUnitWeight: 30000 }  // Tridem drive axle
  * ]);
  * // Returns pass if steer axle weight >= 27% of drive axle weight (8100 kgs)
@@ -416,14 +426,17 @@ export function CheckMinSteerAxleWeight(
   ) {
     // Check minimum load on steer axle
     if (
-      axleConfiguration[0].axleUnitWeight >=
-      axleConfiguration[1].axleUnitWeight * 0.27
+      meetsMinimumSteerPercentageOfDriveAxleWeight(
+        axleConfiguration[0],
+        axleConfiguration[1],
+        0.27,
+      )
     ) {
-      message = 'Steer axle meets minimum weight requirements';
+      message = 'Single steer axle meets minimum weight requirements';
       result = PolicyCheckResultType.Pass;
     } else {
       message =
-        'Steer axle must be a minimum of 27% of tridem drive axle weight';
+        'Single steer axle must be a minimum of 27% of tridem drive axle weight';
       result = PolicyCheckResultType.Fail;
     }
   } else {
@@ -431,6 +444,57 @@ export function CheckMinSteerAxleWeight(
     message = 'Policy check does not apply to this configuration';
     result = PolicyCheckResultType.Pass;
   }
+  policyCheckResults.push({
+    id: policyId,
+    message: message,
+    result: result,
+    startAxleUnit: 1,
+    endAxleUnit: 2,
+  });
+
+  return policyCheckResults;
+}
+
+/**
+ * Validates minimum tandem steer axle weight requirements for tandem steer
+ * power units with tandem or tridem drive axle units. The tandem steer axle
+ * unit must carry at least 40% of the drive axle unit weight.
+ *
+ * @param _policy - The policy instance (unused in this check, but required by PolicyCheck type)
+ * @param _vehicleConfiguration - Vehicle configuration (unused in this check, but required by PolicyCheck type)
+ * @param axleConfiguration - Array of axle configurations containing weight and axle count information
+ * @returns Array of AxleGroupPolicyCheckResult objects with validation results
+ */
+export function CheckMinTandemSteerAxleWeight(
+  _policy: Policy,
+  _vehicleConfiguration: Array<string>,
+  axleConfiguration: Array<AxleConfiguration>,
+): Array<PolicyCheckResult> {
+  const policyCheckResults = new Array<AxleGroupPolicyCheckResult>();
+  const policyId = PolicyCheckId.MinTandemSteerAxleWeight;
+  const steerAxle = axleConfiguration[0];
+  const driveAxle = axleConfiguration[1];
+
+  let message, result;
+  if (
+    steerAxle.numberOfAxles === 2 &&
+    (driveAxle.numberOfAxles === 2 || driveAxle.numberOfAxles === 3)
+  ) {
+    if (
+      meetsMinimumSteerPercentageOfDriveAxleWeight(steerAxle, driveAxle, 0.4)
+    ) {
+      message = 'Tandem steer axle meets minimum weight requirements';
+      result = PolicyCheckResultType.Pass;
+    } else {
+      message =
+        'Tandem steer axle must be a minimum of 40% of drive axle weight';
+      result = PolicyCheckResultType.Fail;
+    }
+  } else {
+    message = 'Policy check does not apply to this configuration';
+    result = PolicyCheckResultType.Pass;
+  }
+
   policyCheckResults.push({
     id: policyId,
     message: message,
@@ -982,6 +1046,7 @@ export function CheckDriveJeepLoadEqualization(
  * - MaxTireLoad: Validates tire load capacity for each axle unit
  * - MinDriveAxleWeight: Validates minimum weight requirements for drive axles
  * - MinSteerAxleWeight: Validates minimum weight requirements for steer axles
+ * - MinTandemSteerAxleWeight: Validates tandem steer minimum weight requirements
  * - NumberOfAxles: Validates axle count per axle unit
  * - NumberOfWheelsPerAxle: Validates tire count per axle unit
  * - BoosterAxleLimit: Validates booster axle count against the preceding trailer
@@ -999,6 +1064,7 @@ export const policyCheckMap = new Map<string, PolicyCheck>([
   [PolicyCheckId.MaxTireLoad, CheckMaxTireLoad],
   [PolicyCheckId.MinDriveAxleWeight, CheckMinDriveAxleWeight],
   [PolicyCheckId.MinSteerAxleWeight, CheckMinSteerAxleWeight],
+  [PolicyCheckId.MinTandemSteerAxleWeight, CheckMinTandemSteerAxleWeight],
   [PolicyCheckId.NumberOfWheelsPerAxle, CheckNumTiresPerAxle],
   [PolicyCheckId.BoosterAxleLimit, CheckBoosterAxleLimit],
   [PolicyCheckId.TruckTractorWheelbase, CheckTruckTractorWheelbase],


### PR DESCRIPTION
This contains the 27% and 40% rule, which are very similar, just differ base on axel configuration. They could be made as one shared eval, but we've kept them split as 2 because they are separate rules in the business domain (although we do have a very small one-line helper for shared functionality of core calculation)

One of the evals was basically already done prior to this PR and just required some refactoring to make it consistent with the other rule. All tests still pass, no regression.

Tests added: covered all BA example rows directly, plus runAxleCalculation and validate coverage for both new failures.