### PR TITLE
feat: ORV2-5456 - 50% rule

### DIFF
--- a/src/_test/unit/axle-calc.spec.ts
+++ b/src/_test/unit/axle-calc.spec.ts
@@ -17,6 +17,7 @@ import {
   CheckMinDriveAxleWeight,
   CheckMinSteerAxleWeight,
   CheckMinTandemSteerAxleWeight,
+  CheckPickerTruckTractorWeightRestrictions,
   CheckTruckTractorWheelbase,
   CheckDriveJeepLoadEqualization,
 } from '../../helper/policy-check.helper';
@@ -469,6 +470,240 @@ describe('Axle Calculation Functions', () => {
     });
   });
 
+  describe('picker truck tractor weight restrictions policy check', () => {
+    const ratioMessage =
+      'Axle Unit 1 must carry a minimum 50% of Axle Unit 2 axle unit weight.';
+    const trailerMessage =
+      'Cannot tow a trailer if Axle Unit 1 and Axle Unit 2 are exceeding legal axle weights.';
+    const getPickerTruckTractorAxles = (
+      steerAxleWeight: number,
+      driveAxleWeight: number,
+      steerAxleSpread = 100,
+      driveAxleSpread = 240,
+      interaxleSpacing = 485,
+    ): Array<AxleConfiguration> => [
+      {
+        numberOfAxles: 2,
+        numberOfTires: 4,
+        tireSize: 330,
+        axleSpread: steerAxleSpread,
+        axleUnitWeight: steerAxleWeight,
+        vehicleIndex: 0,
+      },
+      {
+        numberOfAxles: 3,
+        numberOfTires: 12,
+        tireSize: 330,
+        axleSpread: driveAxleSpread,
+        interaxleSpacing,
+        axleUnitWeight: driveAxleWeight,
+        vehicleIndex: 0,
+      },
+    ];
+    const getResults = (
+      steerAxleWeight: number,
+      driveAxleWeight: number,
+      vehicleTypes = ['PICKRTT'],
+      steerAxleSpread = 100,
+      driveAxleSpread = 240,
+      interaxleSpacing = 485,
+    ) =>
+      CheckPickerTruckTractorWeightRestrictions(
+        policy,
+        vehicleTypes,
+        getPickerTruckTractorAxles(
+          steerAxleWeight,
+          driveAxleWeight,
+          steerAxleSpread,
+          driveAxleSpread,
+          interaxleSpacing,
+        ),
+      );
+
+    it.each([
+      { steerAxleWeight: 10000, driveAxleWeight: 20000 },
+      { steerAxleWeight: 14000, driveAxleWeight: 28000 },
+    ])(
+      'passes the 50% rule for $steerAxleWeight kg steer and $driveAxleWeight kg drive',
+      ({ steerAxleWeight, driveAxleWeight }) => {
+        const [ratioResult] = getResults(steerAxleWeight, driveAxleWeight);
+
+        expect(ratioResult).toMatchObject({
+          id: PolicyCheckId.PickerTruckTractorWeightRestrictions,
+          result: PolicyCheckResultType.Pass,
+          message: '',
+          startAxleUnit: 1,
+          endAxleUnit: 2,
+        });
+      },
+    );
+
+    it('fails the feature example below the 50% requirement', () => {
+      const [ratioResult] = getResults(9000, 20000);
+
+      expect(ratioResult).toMatchObject({
+        id: PolicyCheckId.PickerTruckTractorWeightRestrictions,
+        result: PolicyCheckResultType.Fail,
+        message: ratioMessage,
+      });
+    });
+
+    it.each([
+      {
+        description: 'wheelbase below 6.6m',
+        steerAxleSpread: 100,
+        driveAxleSpread: 240,
+        interaxleSpacing: 485,
+      },
+      {
+        description: 'steer spread below 1.0m',
+        steerAxleSpread: 99,
+        driveAxleSpread: 240,
+        interaxleSpacing: 491,
+      },
+      {
+        description: 'drive spread below 2.4m',
+        steerAxleSpread: 100,
+        driveAxleSpread: 239,
+        interaxleSpacing: 491,
+      },
+    ])(
+      'applies when $description',
+      ({ steerAxleSpread, driveAxleSpread, interaxleSpacing }) => {
+        const [ratioResult] = getResults(
+          9000,
+          20000,
+          ['PICKRTT'],
+          steerAxleSpread,
+          driveAxleSpread,
+          interaxleSpacing,
+        );
+
+        expect(ratioResult).toMatchObject({
+          result: PolicyCheckResultType.Fail,
+          message: ratioMessage,
+        });
+      },
+    );
+
+    it('does not apply when all dimensional thresholds are met', () => {
+      const [result] = getResults(9000, 20000, ['PICKRTT'], 100, 240, 490);
+
+      expect(result).toMatchObject({
+        result: PolicyCheckResultType.Pass,
+        message: 'Policy check does not apply to this configuration',
+      });
+    });
+
+    it.each([
+      {
+        description: 'another power unit subtype',
+        vehicleTypes: ['TRKTRAC'],
+        steerAxleCount: 2,
+        driveAxleCount: 3,
+      },
+      {
+        description: 'single steer',
+        vehicleTypes: ['PICKRTT'],
+        steerAxleCount: 1,
+        driveAxleCount: 3,
+      },
+      {
+        description: 'tandem drive',
+        vehicleTypes: ['PICKRTT'],
+        steerAxleCount: 2,
+        driveAxleCount: 2,
+      },
+    ])(
+      'does not apply to $description',
+      ({ vehicleTypes, steerAxleCount, driveAxleCount }) => {
+        const axles = getPickerTruckTractorAxles(9000, 20000);
+        axles[0].numberOfAxles = steerAxleCount;
+        axles[1].numberOfAxles = driveAxleCount;
+
+        const [result] = CheckPickerTruckTractorWeightRestrictions(
+          policy,
+          vehicleTypes,
+          axles,
+        );
+
+        expect(result).toMatchObject({
+          result: PolicyCheckResultType.Pass,
+          message: 'Policy check does not apply to this configuration',
+        });
+      },
+    );
+
+    it.each([
+      { steerAxleWeight: 15201, driveAxleWeight: 20000 },
+      { steerAxleWeight: 14000, driveAxleWeight: 28001 },
+    ])(
+      'defers weights above configured permit limits to the permittable weight check',
+      ({ steerAxleWeight, driveAxleWeight }) => {
+        const [result] = getResults(steerAxleWeight, driveAxleWeight);
+
+        expect(result).toMatchObject({
+          result: PolicyCheckResultType.Pass,
+          message:
+            'Policy check does not apply outside configured permittable axle weights',
+        });
+      },
+    );
+
+    it('allows a trailer while both axle units remain at legal maximums', () => {
+      const trailerResult = getResults(12000, 24000, ['PICKRTT', 'SEMITRL'])[1];
+
+      expect(trailerResult).toMatchObject({
+        result: PolicyCheckResultType.Pass,
+        message: '',
+      });
+    });
+
+    it.each([
+      { steerAxleWeight: 13601, driveAxleWeight: 24000 },
+      { steerAxleWeight: 14000, driveAxleWeight: 24001 },
+    ])(
+      'rejects a trailer when an axle unit exceeds its legal maximum',
+      ({ steerAxleWeight, driveAxleWeight }) => {
+        const trailerResult = getResults(steerAxleWeight, driveAxleWeight, [
+          'PICKRTT',
+          'SEMITRL',
+        ])[1];
+
+        expect(trailerResult).toMatchObject({
+          result: PolicyCheckResultType.Fail,
+          message: trailerMessage,
+        });
+      },
+    );
+
+    it('does not treat the None pseudo trailer as towing', () => {
+      const trailerResult = getResults(14000, 24001, ['PICKRTT', 'XXXXXXX'])[1];
+
+      expect(trailerResult).toMatchObject({
+        result: PolicyCheckResultType.Pass,
+        message: '',
+      });
+    });
+
+    it('returns both failures when the ratio and trailer rules fail', () => {
+      const results = getResults(13000, 28000, ['PICKRTT', 'SEMITRL']);
+
+      expect(results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            result: PolicyCheckResultType.Fail,
+            message: ratioMessage,
+          }),
+          expect.objectContaining({
+            result: PolicyCheckResultType.Fail,
+            message: trailerMessage,
+          }),
+        ]),
+      );
+    });
+  });
+
   // ORV2-5374 examples and expected pass/fail states come from:
   // onRouteBCSpecification/Applying for Permits/Single Trip Overweight/ASW Tridem Drive AU 20% of Actual GCVW.feature
   describe('minimum drive axle weight policy check', () => {
@@ -706,6 +941,75 @@ describe('Axle Calculation Functions', () => {
       startAxleUnit: 1,
       endAxleUnit: 2,
     });
+  });
+
+  it('should include picker truck tractor weight restriction results from axle calculation', () => {
+    const ac: Array<AxleConfiguration> = [
+      {
+        numberOfAxles: 2,
+        numberOfTires: 4,
+        tireSize: 330,
+        axleSpread: 100,
+        axleUnitWeight: 9000,
+      },
+      {
+        numberOfAxles: 3,
+        numberOfTires: 12,
+        tireSize: 330,
+        axleSpread: 240,
+        interaxleSpacing: 485,
+        axleUnitWeight: 20000,
+      },
+    ];
+
+    const results = policy.runAxleCalculation(['PICKRTT'], ac, 0);
+    const pickerTruckResult = results.results.find(
+      (result) =>
+        result.id === PolicyCheckId.PickerTruckTractorWeightRestrictions &&
+        result.result === PolicyCheckResultType.Fail,
+    );
+
+    expect(pickerTruckResult).toMatchObject({
+      message:
+        'Axle Unit 1 must carry a minimum 50% of Axle Unit 2 axle unit weight.',
+      startAxleUnit: 1,
+      endAxleUnit: 2,
+    });
+  });
+
+  it('should preserve both the 40% and 50% picker truck tractor checks', () => {
+    const ac: Array<AxleConfiguration> = [
+      {
+        numberOfAxles: 2,
+        numberOfTires: 4,
+        tireSize: 330,
+        axleSpread: 100,
+        axleUnitWeight: 10000,
+      },
+      {
+        numberOfAxles: 3,
+        numberOfTires: 12,
+        tireSize: 330,
+        axleSpread: 240,
+        interaxleSpacing: 485,
+        axleUnitWeight: 28000,
+      },
+    ];
+
+    const results = policy.runAxleCalculation(['PICKRTT'], ac, 0);
+
+    expect(results.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: PolicyCheckId.MinTandemSteerAxleWeight,
+          result: PolicyCheckResultType.Fail,
+        }),
+        expect.objectContaining({
+          id: PolicyCheckId.PickerTruckTractorWeightRestrictions,
+          result: PolicyCheckResultType.Fail,
+        }),
+      ]),
+    );
   });
 
   it('should fail policy check for invalid number of tires', async () => {

--- a/src/_test/unit/stow-validation.spec.ts
+++ b/src/_test/unit/stow-validation.spec.ts
@@ -185,6 +185,34 @@ describe('Single Trip Overweight Policy Configuration Validator', () => {
       driveAxleWeight;
   };
 
+  const setPickerTruckTractorScenario = (
+    permit: any,
+    steerAxleWeight: number,
+    driveAxleWeight: number,
+  ) => {
+    permit.permitData.vehicleDetails.vehicleSubType = 'PICKRTT';
+    permit.permitData.vehicleConfiguration.trailers = [];
+    permit.permitData.vehicleConfiguration.axleConfiguration = [
+      {
+        numberOfAxles: 2,
+        numberOfTires: 4,
+        tireSize: 330,
+        axleSpread: 100,
+        axleUnitWeight: steerAxleWeight,
+        vehicleIndex: 0,
+      },
+      {
+        numberOfAxles: 3,
+        numberOfTires: 12,
+        tireSize: 330,
+        axleSpread: 240,
+        interaxleSpacing: 485,
+        axleUnitWeight: driveAxleWeight,
+        vehicleIndex: 0,
+      },
+    ];
+  };
+
   it('should validate STOW successfully', async () => {
     const permit = getDatedPermit();
 
@@ -312,6 +340,52 @@ describe('Single Trip Overweight Policy Configuration Validator', () => {
     );
     expect(validationResult.violations[0].details).toContain(
       'Tandem steer axle must be a minimum of 40% of drive axle weight',
+    );
+  });
+
+  it('should raise STOW axle calculation violation for the picker truck tractor 50% rule', async () => {
+    const permit = getDatedPermit();
+    setPickerTruckTractorScenario(permit, 9000, 20000);
+
+    const validationResult = await policy.validate(permit);
+    const axleViolation = validationResult.violations.find(
+      (violation: any) =>
+        violation.message ===
+        'Vehicle configuration failed axle calculation policy checks',
+    );
+
+    expect(axleViolation?.details).toContain(
+      'Axle Unit 1 must carry a minimum 50% of Axle Unit 2 axle unit weight.',
+    );
+  });
+
+  it('should raise STOW axle calculation violation for the picker truck tractor trailer restriction', async () => {
+    const permit = getDatedPermit();
+    setPickerTruckTractorScenario(permit, 14000, 24001);
+    permit.permitData.vehicleConfiguration.trailers = [
+      {
+        vehicleSubType: 'STACTRN',
+      },
+    ];
+    permit.permitData.vehicleConfiguration.axleConfiguration.push({
+      numberOfAxles: 3,
+      numberOfTires: 12,
+      tireSize: 330,
+      axleSpread: 240,
+      interaxleSpacing: 300,
+      axleUnitWeight: 18000,
+      vehicleIndex: 1,
+    });
+
+    const validationResult = await policy.validate(permit);
+    const axleViolation = validationResult.violations.find(
+      (violation: any) =>
+        violation.message ===
+        'Vehicle configuration failed axle calculation policy checks',
+    );
+
+    expect(axleViolation?.details).toContain(
+      'Cannot tow a trailer if Axle Unit 1 and Axle Unit 2 are exceeding legal axle weights.',
     );
   });
 

--- a/src/enum/policy-check.ts
+++ b/src/enum/policy-check.ts
@@ -14,5 +14,6 @@ export enum PolicyCheckId {
   MinTandemSteerAxleWeight = 'minimum-tandem-steer-axle-weight',
   NumberOfAxles = 'number-of-axles',
   NumberOfWheelsPerAxle = 'number-of-wheels',
+  PickerTruckTractorWeightRestrictions = 'picker-truck-tractor-weight-restrictions',
   TruckTractorWheelbase = 'truck-tractor-wheelbase',
 }

--- a/src/helper/policy-check.helper.ts
+++ b/src/helper/policy-check.helper.ts
@@ -516,6 +516,9 @@ export function CheckPickerTruckTractorWeightRestrictions(
   axleConfiguration: Array<AxleConfiguration>,
 ): Array<AxleGroupPolicyCheckResult> {
   const policyId = PolicyCheckId.PickerTruckTractorWeightRestrictions;
+  const MINIMUM_WHEELBASE_CM = 660;
+  const MINIMUM_STEER_AXLE_SPREAD_CM = 100;
+  const MINIMUM_DRIVE_AXLE_SPREAD_CM = 240;
   const steerAxle = axleConfiguration[0];
   const driveAxle = axleConfiguration[1];
   const doesNotApply = (
@@ -550,9 +553,11 @@ export function CheckPickerTruckTractorWeightRestrictions(
       (driveAxle.axleSpread as number) / 2
     : undefined;
   const isNonStandard =
-    (wheelbase !== undefined && wheelbase < 660) ||
-    (steerAxle.axleSpread !== undefined && steerAxle.axleSpread < 100) ||
-    (driveAxle.axleSpread !== undefined && driveAxle.axleSpread < 240);
+    (wheelbase !== undefined && wheelbase < MINIMUM_WHEELBASE_CM) ||
+    (steerAxle.axleSpread !== undefined &&
+      steerAxle.axleSpread < MINIMUM_STEER_AXLE_SPREAD_CM) ||
+    (driveAxle.axleSpread !== undefined &&
+      driveAxle.axleSpread < MINIMUM_DRIVE_AXLE_SPREAD_CM);
 
   if (!isNonStandard) {
     return doesNotApply();

--- a/src/helper/policy-check.helper.ts
+++ b/src/helper/policy-check.helper.ts
@@ -507,6 +507,127 @@ export function CheckMinTandemSteerAxleWeight(
 }
 
 /**
+ * Applies the restricted weight rules for non-standard tandem steer/tridem
+ * drive picker truck tractors.
+ */
+export function CheckPickerTruckTractorWeightRestrictions(
+  policy: Policy,
+  vehicleConfiguration: Array<string>,
+  axleConfiguration: Array<AxleConfiguration>,
+): Array<AxleGroupPolicyCheckResult> {
+  const policyId = PolicyCheckId.PickerTruckTractorWeightRestrictions;
+  const steerAxle = axleConfiguration[0];
+  const driveAxle = axleConfiguration[1];
+  const doesNotApply = (
+    message = 'Policy check does not apply to this configuration',
+  ): Array<AxleGroupPolicyCheckResult> => [
+    {
+      id: policyId,
+      message,
+      result: PolicyCheckResultType.Pass,
+      startAxleUnit: 1,
+      endAxleUnit: 2,
+    },
+  ];
+
+  if (
+    vehicleConfiguration[0] !== 'PICKRTT' ||
+    !steerAxle ||
+    !driveAxle ||
+    steerAxle.numberOfAxles !== 2 ||
+    driveAxle.numberOfAxles !== 3
+  ) {
+    return doesNotApply();
+  }
+
+  const hasWheelbaseDimensions =
+    Number.isFinite(steerAxle.axleSpread) &&
+    Number.isFinite(driveAxle.interaxleSpacing) &&
+    Number.isFinite(driveAxle.axleSpread);
+  const wheelbase = hasWheelbaseDimensions
+    ? (steerAxle.axleSpread as number) / 2 +
+      (driveAxle.interaxleSpacing as number) +
+      (driveAxle.axleSpread as number) / 2
+    : undefined;
+  const isNonStandard =
+    (wheelbase !== undefined && wheelbase < 660) ||
+    (steerAxle.axleSpread !== undefined && steerAxle.axleSpread < 100) ||
+    (driveAxle.axleSpread !== undefined && driveAxle.axleSpread < 240);
+
+  if (!isNonStandard) {
+    return doesNotApply();
+  }
+
+  const powerUnitWeights = policy.getDefaultPowerUnitWeight('PICKRTT', 23);
+  const steerWeightDimension = policy.selectCorrectWeightDimension(
+    powerUnitWeights,
+    vehicleConfiguration,
+    axleConfiguration,
+    0,
+  );
+  const driveWeightDimension = policy.selectCorrectWeightDimension(
+    powerUnitWeights,
+    vehicleConfiguration,
+    axleConfiguration,
+    1,
+  );
+  const steerPermittable = steerWeightDimension?.permittable;
+  const drivePermittable = driveWeightDimension?.permittable;
+
+  if (
+    steerPermittable === undefined ||
+    drivePermittable === undefined ||
+    steerAxle.axleUnitWeight > steerPermittable ||
+    driveAxle.axleUnitWeight > drivePermittable
+  ) {
+    return doesNotApply(
+      'Policy check does not apply outside configured permittable axle weights',
+    );
+  }
+
+  const ratioPasses = meetsMinimumSteerPercentageOfDriveAxleWeight(
+    steerAxle,
+    driveAxle,
+    0.5,
+  );
+  const hasRealTrailer = vehicleConfiguration.slice(1).some((vehicleType) => {
+    const vehicleDefinition = policy.getVehicleDefinition(vehicleType);
+    return !vehicleDefinition?.ignoreForAxleCalculation;
+  });
+  const exceedsLegalWeight =
+    (steerWeightDimension?.legal !== undefined &&
+      steerAxle.axleUnitWeight > steerWeightDimension.legal) ||
+    (driveWeightDimension?.legal !== undefined &&
+      driveAxle.axleUnitWeight > driveWeightDimension.legal);
+  const trailerPasses = !hasRealTrailer || !exceedsLegalWeight;
+
+  return [
+    {
+      id: policyId,
+      message: ratioPasses
+        ? ''
+        : 'Axle Unit 1 must carry a minimum 50% of Axle Unit 2 axle unit weight.',
+      result: ratioPasses
+        ? PolicyCheckResultType.Pass
+        : PolicyCheckResultType.Fail,
+      startAxleUnit: 1,
+      endAxleUnit: 2,
+    },
+    {
+      id: policyId,
+      message: trailerPasses
+        ? ''
+        : 'Cannot tow a trailer if Axle Unit 1 and Axle Unit 2 are exceeding legal axle weights.',
+      result: trailerPasses
+        ? PolicyCheckResultType.Pass
+        : PolicyCheckResultType.Fail,
+      startAxleUnit: 1,
+      endAxleUnit: 2,
+    },
+  ];
+}
+
+/**
  * Validates minimum drive axle weight requirements for tandem and tridem drive power units.
  *
  * This function checks that the drive axle meets minimum weight requirements based on the
@@ -1047,6 +1168,7 @@ export function CheckDriveJeepLoadEqualization(
  * - MinDriveAxleWeight: Validates minimum weight requirements for drive axles
  * - MinSteerAxleWeight: Validates minimum weight requirements for steer axles
  * - MinTandemSteerAxleWeight: Validates tandem steer minimum weight requirements
+ * - PickerTruckTractorWeightRestrictions: Validates non-standard picker truck tractor restrictions
  * - NumberOfAxles: Validates axle count per axle unit
  * - NumberOfWheelsPerAxle: Validates tire count per axle unit
  * - BoosterAxleLimit: Validates booster axle count against the preceding trailer
@@ -1065,6 +1187,10 @@ export const policyCheckMap = new Map<string, PolicyCheck>([
   [PolicyCheckId.MinDriveAxleWeight, CheckMinDriveAxleWeight],
   [PolicyCheckId.MinSteerAxleWeight, CheckMinSteerAxleWeight],
   [PolicyCheckId.MinTandemSteerAxleWeight, CheckMinTandemSteerAxleWeight],
+  [
+    PolicyCheckId.PickerTruckTractorWeightRestrictions,
+    CheckPickerTruckTractorWeightRestrictions,
+  ],
   [PolicyCheckId.NumberOfWheelsPerAxle, CheckNumTiresPerAxle],
   [PolicyCheckId.BoosterAxleLimit, CheckBoosterAxleLimit],
   [PolicyCheckId.TruckTractorWheelbase, CheckTruckTractorWheelbase],


### PR DESCRIPTION
<img width="2226" height="1292" alt="image" src="https://github.com/user-attachments/assets/6057c8c7-e943-44c0-8950-b9e89574a9bc" />

This one is tested out locally via npm link, and once we approve and publish this, I will submit the frontend PR with the published version included.