### PR TITLE
feat: Harmonize validate() and runAxleCalculations()

### DIFF
--- a/src/_test/unit/stow-validation.spec.ts
+++ b/src/_test/unit/stow-validation.spec.ts
@@ -3,6 +3,7 @@ import currentConfig from '../policy-config/_current-config.json';
 import testStow from '../permit-app/test-stow.json';
 import dayjs from 'dayjs';
 import { PermitAppInfo } from '../../enum/permit-app-info';
+import { PolicyCheckId, PolicyCheckResultType } from '../../enum/policy-check';
 
 const reportedTrailerCrashInput = {
   currentFormData: {
@@ -280,6 +281,46 @@ describe('Single Trip Overweight Policy Configuration Validator', () => {
     expect(validationResult.violations[0].details).toContain(
       'No. of Wheels for Axle Unit 2 is not permittable.',
     );
+  });
+
+  it('should return structured axle calculation results from validate for nested trailer axle configuration', async () => {
+    const permit = getDatedPermit();
+    const axleConfiguration =
+      permit.permitData.vehicleConfiguration.axleConfiguration;
+    permit.permitData.vehicleConfiguration.axleConfiguration =
+      axleConfiguration.slice(0, 2);
+    permit.permitData.vehicleConfiguration.trailers[0].axleConfiguration = [
+      {
+        ...axleConfiguration[2],
+        numberOfTires: 3,
+      },
+    ];
+    permit.permitData.vehicleConfiguration.trailers[1].axleConfiguration = [
+      axleConfiguration[3],
+    ];
+    permit.permitData.vehicleConfiguration.trailers[2].axleConfiguration = [
+      axleConfiguration[4],
+    ];
+
+    const validationResult = await policy.validate(permit);
+    const wheelCountFailure =
+      validationResult.axleCalculationResults?.results.find(
+        (result) =>
+          result.id === PolicyCheckId.NumberOfWheelsPerAxle &&
+          result.result === PolicyCheckResultType.Fail,
+      );
+
+    expect(validationResult.violations[0].message).toBe(
+      'Vehicle configuration failed axle calculation policy checks',
+    );
+    expect(validationResult.violations[0].details).toContain(
+      'No. of Wheels for Axle Unit 3 is not permittable.',
+    );
+    expect(wheelCountFailure).toMatchObject({
+      message: 'No. of Wheels for Axle Unit 3 is not permittable.',
+      startAxleUnit: 3,
+      endAxleUnit: 3,
+    });
   });
 
   it('should raise STOW axle calculation violation when truck tractor wheelbase exceeds 7.2m', async () => {

--- a/src/enum/facts.ts
+++ b/src/enum/facts.ts
@@ -1,5 +1,6 @@
 export enum PolicyFacts {
   AllowedVehicles = 'allowedVehicles',
+  AxleCalcResults = 'axleCalcResults',
   AxleCalcViolations = 'axleCalcViolations',
   ConfigurationIsValid = 'configurationIsValid',
   DaysBetween = 'daysBetween',

--- a/src/helper/facts.helper.ts
+++ b/src/helper/facts.helper.ts
@@ -9,6 +9,7 @@ import {
 } from 'onroute-policy-engine/enum';
 import { Policy } from 'onroute-policy-engine';
 import {
+  AxleCalcResults,
   AxleConfiguration,
   PermitType,
   PermitVehicleDetails,
@@ -18,6 +19,53 @@ import {
 import { policyCheckMap } from './policy-check.helper';
 
 dayjs.extend(quarterOfYear);
+
+const AXLE_CALC_RESULTS_FACT = 'axleCalcResults';
+
+type AxleCalculationInputs = {
+  vehicleConfiguration: Array<string>;
+  axleConfiguration: Array<AxleConfiguration>;
+  licensedGVW: number;
+};
+
+const getAxleCalculationInputs = async (
+  policy: Policy,
+  almanac: any,
+): Promise<AxleCalculationInputs> => {
+  const vehicleDetails: PermitVehicleDetails = await almanac.factValue(
+    PermitAppInfo.PermitData,
+    {},
+    PermitAppInfo.VehicleDetails,
+  );
+  const vehicleConfigurationData: VehicleConfiguration =
+    await almanac.factValue(
+      PermitAppInfo.PermitData,
+      {},
+      PermitAppInfo.VehicleConfiguration,
+    );
+  const vehicleConfiguration = policy.getSimplifiedVehicleConfiguration(
+    vehicleDetails,
+    vehicleConfigurationData,
+  );
+  const powerUnitAxleConfiguration =
+    vehicleConfigurationData?.axleConfiguration ?? [];
+  const trailers = vehicleConfigurationData?.trailers ?? [];
+  const hasNestedTrailerAxleConfiguration = trailers.some(
+    (trailer) =>
+      Array.isArray(trailer.axleConfiguration) &&
+      trailer.axleConfiguration.length > 0,
+  );
+  const axleConfiguration =
+    hasNestedTrailerAxleConfiguration
+      ? policy.combineAxleConfigurations(powerUnitAxleConfiguration, trailers)
+      : powerUnitAxleConfiguration;
+
+  return {
+    vehicleConfiguration,
+    axleConfiguration,
+    licensedGVW: vehicleDetails.licensedGVW || 0,
+  };
+};
 
 /**
  * Adds runtime facts for the validation. For example, adds the
@@ -208,13 +256,10 @@ export function addRuntimeFacts(engine: Engine, policy: Policy): void {
   engine.addFact(
     PolicyFacts.GrossVehicleCombinationWeight,
     async function (params, almanac) {
-      // Retrieve the axle configuration from permit data
-      const axleConfiguration: Array<AxleConfiguration> =
-        await almanac.factValue(
-          PermitAppInfo.PermitData,
-          {},
-          PermitAppInfo.AxleConfiguration,
-        );
+      const { axleConfiguration } = await getAxleCalculationInputs(
+        policy,
+        almanac,
+      );
       return axleConfiguration.reduce((w, curr) => w + curr.axleUnitWeight, 0);
     },
   );
@@ -227,17 +272,8 @@ export function addRuntimeFacts(engine: Engine, policy: Policy): void {
   engine.addFact(
     PolicyFacts.PolicyCheckPassed.toString(),
     async function (params, almanac) {
-      // Retrieve the complete vehicle configuration (power unit + trailers)
-      const vehicleConfiguration: Array<string> = await almanac.factValue(
-        PolicyFacts.VehicleConfiguration,
-      );
-      // Retrieve the axle configuration from permit data
-      const axleConfiguration: Array<AxleConfiguration> =
-        await almanac.factValue(
-          PermitAppInfo.PermitData,
-          {},
-          PermitAppInfo.AxleConfiguration,
-        );
+      const { vehicleConfiguration, axleConfiguration } =
+        await getAxleCalculationInputs(policy, almanac);
       // Get the specific policy check ID from parameters
       const policyCheckId = params.policyId;
 
@@ -265,35 +301,32 @@ export function addRuntimeFacts(engine: Engine, policy: Policy): void {
   );
 
   /**
-   * Add runtime fact to return an array of all messages that result from
-   * all combined policy checks for axle calculation. This is used in
-   * permit validation, returned in the details param for that rule for
-   * overweight permit types.
+   * Add runtime fact to return the complete runAxleCalculation result. This
+   * is the structured ASW validation detail exposed by validate().
+   */
+  engine.addFact(
+    AXLE_CALC_RESULTS_FACT,
+    async function (params, almanac) {
+      const { vehicleConfiguration, axleConfiguration, licensedGVW } =
+        await getAxleCalculationInputs(policy, almanac);
+      return policy.runAxleCalculation(
+        vehicleConfiguration,
+        axleConfiguration,
+        licensedGVW,
+      );
+    },
+  );
+
+  /**
+   * Add runtime fact to return messages from failed axle calculation checks.
+   * This keeps the generic validation violation as the gating signal while
+   * axleCalcResults carries the structured ASW detail.
    */
   engine.addFact(
     PolicyFacts.AxleCalcViolations,
     async function (params, almanac) {
-      // Retrieve the complete vehicle configuration (power unit + trailers)
-      const vehicleConfiguration: Array<string> = await almanac.factValue(
-        PolicyFacts.VehicleConfiguration,
-      );
-      // Retrieve the axle configuration from permit data
-      const axleConfiguration: Array<AxleConfiguration> =
-        await almanac.factValue(
-          PermitAppInfo.PermitData,
-          {},
-          PermitAppInfo.AxleConfiguration,
-        );
-      // Retrieve licensed GVW from permit data
-      const vehicleDetails: PermitVehicleDetails = await almanac.factValue(
-        PermitAppInfo.PermitData,
-        {},
-        PermitAppInfo.VehicleDetails,
-      );
-      const results = policy.runAxleCalculation(
-        vehicleConfiguration,
-        axleConfiguration,
-        vehicleDetails.licensedGVW || 0,
+      const results: AxleCalcResults = await almanac.factValue(
+        AXLE_CALC_RESULTS_FACT,
       );
       const violations = results.results.filter(
         (r) => r.result === PolicyCheckResultType.Fail,

--- a/src/policy-engine.ts
+++ b/src/policy-engine.ts
@@ -162,6 +162,16 @@ export class Policy {
 
       // Wrap the json-rules-engine result in a ValidationResult object
       const validationResults = new ValidationResults(engineResult);
+      const shouldIncludeAxleCalculationResults =
+        permit.permitType === 'STOW' &&
+        permit.permitData?.vehicleConfiguration?.axleConfiguration;
+
+      if (shouldIncludeAxleCalculationResults) {
+        validationResults.axleCalculationResults =
+          await engineResult.almanac.factValue<AxleCalcResults>(
+            'axleCalcResults',
+          );
+      }
 
       // Include an informational message if the client is an LCV carrier
       if (this.specialAuthorizations?.isLcvAllowed) {

--- a/src/validation-results.ts
+++ b/src/validation-results.ts
@@ -2,6 +2,7 @@ import { EngineResult } from 'json-rules-engine';
 import { ValidationResultType } from './enum/validation-result-type';
 import { ValidationResultCode } from './enum/validation-result-code';
 import { ValidationResult } from './validation-result';
+import { AxleCalcResults } from './types/axle-calculation-results';
 
 /** Represents the results of a permit application validation against policy */
 export class ValidationResults {
@@ -26,6 +27,13 @@ export class ValidationResults {
    * one cost message, all should be summed to get the total permit cost.
    */
   cost: Array<ValidationResult> = [];
+
+  /**
+   * Structured axle-spacing-and-weights policy-check results. This mirrors
+   * runAxleCalculation() so consumers can highlight ASW fields while
+   * violations remains the coarse validation-gating signal.
+   */
+  axleCalculationResults?: AxleCalcResults;
 
   /**
    * Creates a new ValidationResults from the json-rules-engine result.


### PR DESCRIPTION
This is the big PR that gets validate() and runAxleCalculations() working. I think it's working fine, but Glen please review.

Frontend-PR (both PRs must be reviewed and tested together!): https://github.com/bcgov/onroutebc/pull/2306#pullrequestreview-4583151345

Pull out this branch, and frontend's branch. Run npm link and npm run build on policy engine; and link to it from the frontend. When that's done, test out some ASW changes and using the continue button to trigger validate.



 0. Fixed the likely validate() crash path. validate() was still effectively using the old flat ASW axle config shape, while the frontend now stores axle data across the power unit and trailers (remember the vehicleIndex stuff?). We now build the full axle config from the nested vehicle/trailer shape before running STOW axle checks, so validate is no longer running those checks against incomplete axle data.

 1. The main change is that validate() now returns the same structured ASW results as runAxleCalculation(), under a new property: `axleCalculationResults`.

2. We kept the existing generic violations behaviour, because that still works well for blocking/gating the form, and all our tests expect this. The new structured field is just the detail the frontend needs for ASW messages and field highlighting. We still honour that existing contract that if anything appears in the `validations` array returned from `validate()` that stuff is fundamentally wrong. All our testing is built up around this too, this is the fundamental contract. We provide additional ASW info in a separate object (not in `validations` array) so we can do ASW frontend highlightiing.

3. The frontend now passes validate-returned ASW results down to the ASW table, so clicking Continue/Validate can show the same kind of ASW feedback as clicking Calculate. That is happened in a separate PR, but the two should be done together.



4. Note: There is a minor issue with GCVW on the frontend here. Basically we can show it if we run runAxleCalc, but not for validate(). Might take a bit of extra work here, or perhaps isn't necessary? To be clear this is in the OTHER PR, not this PR. Here is a link to the specific issue: https://github.com/bcgov/onroutebc/pull/2306#discussion_r3484490985 