### PR TITLE
fix: Fix CheckPermittableWeight - 'Error missing weight dimensions' for CONCRET with 21 axel

### DIFF
--- a/src/_test/unit/multi-axle.spec.ts
+++ b/src/_test/unit/multi-axle.spec.ts
@@ -2,6 +2,7 @@ import { Policy } from '../../policy-engine';
 import { PolicyCheckId, PolicyCheckResultType } from '../../enum';
 import { getAxleUnitVehicleIndexes } from '../../helper/dimensions.helper';
 import currentPolicyConfig from '../policy-config/_current-config.json';
+import { AxleCalcResults } from '../../types';
 
 describe('Multi-Axle Unit Calculation Tests', () => {
   const policy: Policy = new Policy(currentPolicyConfig);
@@ -34,6 +35,57 @@ describe('Multi-Axle Unit Calculation Tests', () => {
     expect(
       results.results.every((r) => r.result === PolicyCheckResultType.Pass),
     ).toBe(true);
+  });
+
+  it('should return policy results for a concrete truck with unsupported tandem steer and single drive weights', () => {
+    let results: AxleCalcResults | undefined;
+
+    expect(() => {
+      results = policy.runAxleCalculation(
+        ['CONCRET'],
+        [
+          {
+            numberOfAxles: 2,
+            axleSpread: 200,
+            axleUnitWeight: 2000,
+            numberOfTires: 2,
+            tireSize: 279,
+            vehicleIndex: 0,
+          },
+          {
+            numberOfAxles: 1,
+            interaxleSpacing: 200,
+            axleUnitWeight: 2000,
+            numberOfTires: 2,
+            tireSize: 279,
+            vehicleIndex: 0,
+          },
+        ],
+        4000,
+      );
+    }).not.toThrow();
+
+    expect(results!.totalOverload).toBe(0);
+    expect(results!.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: PolicyCheckId.CheckPermittableWeight,
+          result: PolicyCheckResultType.Fail,
+          startAxleUnit: 1,
+          endAxleUnit: 1,
+          actualWeight: 2000,
+          thresholdWeight: 0,
+        }),
+        expect.objectContaining({
+          id: PolicyCheckId.CheckPermittableWeight,
+          result: PolicyCheckResultType.Fail,
+          startAxleUnit: 2,
+          endAxleUnit: 2,
+          actualWeight: 2000,
+          thresholdWeight: 0,
+        }),
+      ]),
+    );
   });
 
   it('should pass when a trailer is explicitly configured with an extra axle unit', () => {

--- a/src/helper/policy-check.helper.ts
+++ b/src/helper/policy-check.helper.ts
@@ -364,12 +364,14 @@ export function CheckPermittableWeight(
           )
         : policy.getDefaultTrailerWeight(vehicleType, ac.numberOfAxles);
     const axleDimension =
-      policy.selectCorrectWeightDimension(
-        weight,
-        vehicleConfiguration,
-        axleConfiguration,
-        i,
-      ) || {};
+      weight.length > 0
+        ? policy.selectCorrectWeightDimension(
+            weight,
+            vehicleConfiguration,
+            axleConfiguration,
+            i,
+          ) || {}
+        : {};
     const actualWeight = ac.axleUnitWeight;
     const permittableWeight = axleDimension.permittable || 0;
     const result = actualWeight <= permittableWeight;


### PR DESCRIPTION
Fixes an issue with CheckPermittableWeight STOW Eval.

This fixes an issue Glen sent to me in a message, with the following input:

```json
{
  "simplifiedVehicleConfiguration": [
    "CONCRET"
  ],
  "axleConfiguration": [
    {
      "numberOfAxles": 2,
      "axleSpread": 200,
      "axleUnitWeight": 2000,
      "numberOfTires": 2,
      "tireSize": 279,
      "vehicleIndex": 0
    },
    {
      "numberOfAxles": 1,
      "interaxleSpacing": 200,
      "axleUnitWeight": 2000,
      "numberOfTires": 2,
      "tireSize": 279,
      "vehicleIndex": 0
    }
  ],
  "licensedGVW": 4000
}

```