### PR TITLE
feat: ORV2-5753 - STOW ASW Evaluation: Licensed GVW vs Actual GVW

### DIFF
--- a/src/_test/unit/configuration.spec.ts
+++ b/src/_test/unit/configuration.spec.ts
@@ -122,25 +122,6 @@ describe('Policy Engine Vehicle Configuration Helpers', () => {
       },
     ]);
   });
-
-  it('should calculate GCVW from axle unit weights', () => {
-    const gcvw = policy.calculateGCVW([
-      {
-        numberOfAxles: 1,
-        axleUnitWeight: 5000,
-      },
-      {
-        numberOfAxles: 2,
-        axleUnitWeight: 12000,
-      },
-      {
-        numberOfAxles: 1,
-        axleUnitWeight: 4000,
-      },
-    ]);
-
-    expect(gcvw).toBe(21000);
-  });
 });
 
 describe('Policy Engine Get Next Permittable Vehicles', () => {
@@ -478,32 +459,68 @@ describe('Policy Engine Configuration Validation', () => {
   });
 
   it('should allow axle units to be added for allowed power units', async () => {
-    const canAddAxleUnits1 = policy.canAddAxleUnitsToPowerUnit('STOW', 'XXXXXXX', 'CONCRET');
-    const canAddAxleUnits2 = policy.canAddAxleUnitsToPowerUnit('STOW', 'XXXXXXX', 'CRANEAT');
-    
+    const canAddAxleUnits1 = policy.canAddAxleUnitsToPowerUnit(
+      'STOW',
+      'XXXXXXX',
+      'CONCRET',
+    );
+    const canAddAxleUnits2 = policy.canAddAxleUnitsToPowerUnit(
+      'STOW',
+      'XXXXXXX',
+      'CRANEAT',
+    );
+
     expect(canAddAxleUnits1).toBe(true);
     expect(canAddAxleUnits2).toBe(true);
   });
 
   it('should not allow axle units to be added for non-allowable power units', async () => {
-    const canAddAxleUnits1 = policy.canAddAxleUnitsToPowerUnit('STOW', 'XXXXXXX', 'CRANEMB');
-    const canAddAxleUnits2 = policy.canAddAxleUnitsToPowerUnit('STOW', 'EMPTYXX', 'TRKTRAC');
-    
+    const canAddAxleUnits1 = policy.canAddAxleUnitsToPowerUnit(
+      'STOW',
+      'XXXXXXX',
+      'CRANEMB',
+    );
+    const canAddAxleUnits2 = policy.canAddAxleUnitsToPowerUnit(
+      'STOW',
+      'EMPTYXX',
+      'TRKTRAC',
+    );
+
     expect(canAddAxleUnits1).toBe(false);
     expect(canAddAxleUnits2).toBe(false);
   });
 
   it('should allow axle units to be added for allowed trailers', async () => {
-    const canAddAxleUnits1 = policy.canAddAxleUnitsToTrailer('STOW', 'XXXXXXX', 'CRANEMB', 'DOLLIES');
-    const canAddAxleUnits2 = policy.canAddAxleUnitsToTrailer('STOW', 'XXXXXXX', 'PICKRTT', 'PLATWHE');
+    const canAddAxleUnits1 = policy.canAddAxleUnitsToTrailer(
+      'STOW',
+      'XXXXXXX',
+      'CRANEMB',
+      'DOLLIES',
+    );
+    const canAddAxleUnits2 = policy.canAddAxleUnitsToTrailer(
+      'STOW',
+      'XXXXXXX',
+      'PICKRTT',
+      'PLATWHE',
+    );
 
     expect(canAddAxleUnits1).toBe(true);
     expect(canAddAxleUnits2).toBe(true);
   });
 
   it('should not allow axle units to be added for non-allowable trailers', async () => {
-    const canAddAxleUnits1 = policy.canAddAxleUnitsToTrailer('STOW', 'EMPTYXX', 'PICKRTT', 'SEMITRL');
-    const canAddAxleUnits2 = policy.canAddAxleUnitsToTrailer('STOW', 'NONREDU', 'PICKRTT', 'SEMITRL');
+    const canAddAxleUnits1 = policy.canAddAxleUnitsToTrailer(
+      'STOW',
+      'EMPTYXX',
+      'PICKRTT',
+      'SEMITRL',
+    );
+    const canAddAxleUnits2 = policy.canAddAxleUnitsToTrailer(
+      'STOW',
+      'NONREDU',
+      'PICKRTT',
+      'SEMITRL',
+    );
 
     expect(canAddAxleUnits1).toBe(false);
     expect(canAddAxleUnits2).toBe(false);

--- a/src/_test/unit/multi-axle.spec.ts
+++ b/src/_test/unit/multi-axle.spec.ts
@@ -31,7 +31,7 @@ describe('Multi-Axle Unit Calculation Tests', () => {
       15000,
     );
 
-    expect(results.totalOverload).toBe(0);
+    expect(results.overload).toBe(0);
     expect(
       results.results.every((r) => r.result === PolicyCheckResultType.Pass),
     ).toBe(true);
@@ -65,7 +65,7 @@ describe('Multi-Axle Unit Calculation Tests', () => {
       );
     }).not.toThrow();
 
-    expect(results!.totalOverload).toBe(0);
+    expect(results!.overload).toBe(0);
     expect(results!.results).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -106,7 +106,7 @@ describe('Multi-Axle Unit Calculation Tests', () => {
       20000,
     );
 
-    expect(results.totalOverload).toBe(0);
+    expect(results.overload).toBe(0);
     expect(
       results.results.every((r) => r.result === PolicyCheckResultType.Pass),
     ).toBe(true);
@@ -143,7 +143,7 @@ describe('Multi-Axle Unit Calculation Tests', () => {
       15000,
     );
 
-    expect(results.totalOverload).toBe(0);
+    expect(results.overload).toBe(0);
     expect(results.results).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -177,7 +177,7 @@ describe('Multi-Axle Unit Calculation Tests', () => {
       25000,
     );
 
-    expect(results.totalOverload).toBe(0);
+    expect(results.overload).toBe(0);
     expect(
       results.results.every((r) => r.result === PolicyCheckResultType.Pass),
     ).toBe(true);
@@ -215,7 +215,7 @@ describe('Multi-Axle Unit Calculation Tests', () => {
       15000,
     );
 
-    expect(results.totalOverload).toBe(0);
+    expect(results.overload).toBe(0);
     expect(
       results.results.every((r) => r.result === PolicyCheckResultType.Pass),
     ).toBe(true);
@@ -255,7 +255,7 @@ describe('Multi-Axle Unit Calculation Tests', () => {
       15000,
     );
 
-    expect(results.totalOverload).toBe(0);
+    expect(results.overload).toBe(0);
     expect(
       results.results.every((r) => r.result === PolicyCheckResultType.Pass),
     ).toBe(true);
@@ -313,7 +313,7 @@ describe('Multi-Axle Unit Calculation Tests', () => {
       25000,
     );
 
-    expect(results.totalOverload).toBe(0);
+    expect(results.overload).toBe(0);
     expect(
       results.results.every((r) => r.result === PolicyCheckResultType.Pass),
     ).toBe(true);

--- a/src/helper/vehicles.helper.ts
+++ b/src/helper/vehicles.helper.ts
@@ -168,18 +168,3 @@ export function combineAxleConfigurationsHelper(
 
   return [...powerUnitAxles, ...trailerAxles];
 }
-
-/**
- * Calculates the Gross Combined Vehicle Weight (GCVW) from axle unit weights.
- *
- * @param axleConfiguration - Axle configuration to total
- * @returns Sum of axle unit weights, treating missing weights as 0.
- */
-export function calculateGCVWHelper(
-  axleConfiguration: Array<AxleConfiguration>,
-): number {
-  return axleConfiguration.reduce((totalWeight, axleUnit) => {
-    const axleUnitWeight = axleUnit.axleUnitWeight ?? 0;
-    return totalWeight + axleUnitWeight;
-  }, 0);
-}

--- a/src/policy-engine.ts
+++ b/src/policy-engine.ts
@@ -50,7 +50,6 @@ import { SpecialAuthorizations } from './types/special-authorizations';
 import {
   filterOutLcv,
   filterVehiclesByType,
-  calculateGCVWHelper,
   combineAxleConfigurationsHelper,
   getSimplifiedVehicleConfigurationHelper,
 } from './helper/vehicles.helper';
@@ -1292,16 +1291,6 @@ export class Policy {
       powerUnitAxleConfiguration,
       trailers,
     );
-  }
-
-  /**
-   * Calculates the Gross Combined Vehicle Weight (GCVW) from axle unit weights.
-   *
-   * @param axleConfiguration - Axle configuration to total
-   * @returns Sum of axle unit weights, treating missing weights as 0.
-   */
-  calculateGCVW(axleConfiguration: Array<AxleConfiguration>): number {
-    return calculateGCVWHelper(axleConfiguration);
   }
 
   /**

--- a/src/policy-engine.ts
+++ b/src/policy-engine.ts
@@ -989,7 +989,11 @@ export class Policy {
     axleConfiguration: Array<AxleConfiguration>,
     licensedGVW: number,
   ): AxleCalcResults {
-    const axleCalcResults: AxleCalcResults = { results: [], totalOverload: 0 };
+    const axleCalcResults: AxleCalcResults = {
+      results: [],
+      overload: 0,
+      totalGCVW: 0,
+    };
 
     // This is a little helper closure that just converts any PolicyCheckResult into an AxleGroupPolicyCheckResult,
     // basically giving us startAxleUnit and endAxleUnit, which can help with frontend form highlighting.
@@ -1018,11 +1022,11 @@ export class Policy {
       (w, curr) => w + curr.axleUnitWeight,
       0,
     );
-    axleCalcResults.totalOverload = Math.max(
-      axleCalcResults.totalOverload,
+    axleCalcResults.overload = Math.max(
+      axleCalcResults.overload,
       gvcw - licensedGVW,
     );
-
+    axleCalcResults.totalGCVW = gvcw;
     const axleCountResults = CheckNumberOfAxles(
       this,
       vehicleConfiguration,
@@ -1400,8 +1404,10 @@ export class Policy {
       return false;
     }
 
-    const trailer = powerUnit.trailers.find(trailer => trailer.type === trailerSubtype);
-      
+    const trailer = powerUnit.trailers.find(
+      (trailer) => trailer.type === trailerSubtype,
+    );
+
     if (!trailer) {
       throw new Error(`Invalid trailer: '${trailerSubtype}'`);
     }

--- a/src/types/axle-calculation-results.ts
+++ b/src/types/axle-calculation-results.ts
@@ -5,7 +5,10 @@
  * Used for validating vehicle configurations against weight and axle requirements.
  */
 
-import { PolicyCheckId, PolicyCheckResultType } from 'onroute-policy-engine/enum';
+import {
+  PolicyCheckId,
+  PolicyCheckResultType,
+} from 'onroute-policy-engine/enum';
 
 /**
  * Complete results from axle calculations including all policy checks and total overload
@@ -14,7 +17,9 @@ export type AxleCalcResults = {
   /** Array of individual axle group policy check results */
   results: Array<AxleGroupPolicyCheckResult>;
   /** Total weight overload across all axles in kilograms */
-  totalOverload: number;
+  overload: number;
+  /** Total Gross Combined Vehicle Weight across all axles in kilograms */
+  totalGCVW: number;
 };
 
 /**
@@ -27,7 +32,7 @@ export type PolicyCheckResult = {
   thresholdWeight?: number;
   /** Unique identifier for the policy check */
   // id: string;
-  id: PolicyCheckId
+  id: PolicyCheckId;
   /** Result of the policy check (pass/fail) */
   result: PolicyCheckResultType;
   /** Human-readable message describing the check result */


### PR DESCRIPTION
Return overload property from runAxleCalculation and remove calculateGCVW helper function since it is no longer consumed by the frontend