### PR TITLE
fix: return-correct-start-axle-unit-from-check-booster

### DIFF
--- a/src/helper/policy-check.helper.ts
+++ b/src/helper/policy-check.helper.ts
@@ -996,6 +996,7 @@ export function CheckBoosterAxleLimit(
         message: result
           ? ''
           : `No. of Axles for Axle Unit ${boosterAxleUnit} must be less than or equal to No. of Axles for Axle Unit ${trailerAxleUnit}`,
+        // startAxleUnit and endAxleUnit should be the same for field highlighting purposes
         startAxleUnit: boosterAxleUnit,
         endAxleUnit: boosterAxleUnit,
       });

--- a/src/helper/policy-check.helper.ts
+++ b/src/helper/policy-check.helper.ts
@@ -996,7 +996,7 @@ export function CheckBoosterAxleLimit(
         message: result
           ? ''
           : `No. of Axles for Axle Unit ${boosterAxleUnit} must be less than or equal to No. of Axles for Axle Unit ${trailerAxleUnit}`,
-        startAxleUnit: trailerAxleUnit,
+        startAxleUnit: boosterAxleUnit,
         endAxleUnit: boosterAxleUnit,
       });
       return;


### PR DESCRIPTION
CheckBoosterAxleLimit now returns boosterAxleUnit for startAxleUnit