### PR TITLE
fix: Crashing due to JSON rules parsing logic for custom weight dimen…

### DIFF
--- a/src/_test/unit/multi-axle.spec.ts
+++ b/src/_test/unit/multi-axle.spec.ts
@@ -112,6 +112,54 @@ describe('Multi-Axle Unit Calculation Tests', () => {
     ).toBe(true);
   });
 
+  it('should calculate a truck tractor with a tridem semi-trailer axle unit', () => {
+    const results = policy.runAxleCalculation(
+      ['TRKTRAC', 'SEMITRL'],
+      [
+        {
+          numberOfAxles: 1,
+          axleUnitWeight: 5000,
+          numberOfTires: 2,
+          tireSize: 279,
+          vehicleIndex: 0,
+        },
+        {
+          numberOfAxles: 2,
+          axleSpread: 140,
+          interaxleSpacing: 660,
+          axleUnitWeight: 5000,
+          numberOfTires: 4,
+          tireSize: 279,
+          vehicleIndex: 0,
+        },
+        {
+          numberOfAxles: 3,
+          axleSpread: 200,
+          interaxleSpacing: 200,
+          axleUnitWeight: 5000,
+          numberOfTires: 6,
+          tireSize: 279,
+          vehicleIndex: 1,
+        },
+      ],
+      30000,
+    );
+
+    expect(results.totalGCVW).toBe(15000);
+    expect(results.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: PolicyCheckId.CheckPermittableWeight,
+          result: PolicyCheckResultType.Pass,
+          startAxleUnit: 3,
+          endAxleUnit: 3,
+          actualWeight: 5000,
+          thresholdWeight: 29000,
+        }),
+      ]),
+    );
+  });
+
   it('should calculate PICKRTT and PLATFRM with one-axle trailer defaults and report tire failures', () => {
     const results = policy.runAxleCalculation(
       ['PICKRTT', 'PLATFRM'],

--- a/src/helper/dimensions.helper.ts
+++ b/src/helper/dimensions.helper.ts
@@ -498,6 +498,9 @@ export function selectCorrectWeightDimensionHelper(
             isMatch =
               matcher ==
               (isTypeMatch ? relatives.nextType : relatives.nextCategory);
+            if (!isMatch) {
+              break;
+            }
             if (isMatch && m.axles) {
               isMatch =
                 m.axles == axleConfiguration[axleIndex + 1].numberOfAxles;


### PR DESCRIPTION
…sion validator logic.

This logic is for parsing defaultWeightDimensions in JSON. There was an error in it, which we've fixed by returning early. This is totally fine to do, 'cause we're only returning after we don't find a match, and if we don't find a match at the beginning of our section of code we will never find one later. This is even better than just a nullcheck (which would work), because we stop searching for candidates we know are not there.

All in all, this is a really quick fix, but took a while to understand what the function was doing and why this change is a safe change to make.