### PR TITLE
feat: Add new PME vehicle types. WILL REQUIRE DB WORK!

### DIFF
--- a/src/_test/policy-config/_current-config.json
+++ b/src/_test/policy-config/_current-config.json
@@ -1530,6 +1530,8 @@
         "OGSRRAH",
         "PICKRTR",
         "PICKRTT",
+        "TRUCKPME",
+        "TRACPME",
         "RBTRLDR",
         "SCRAPER",
         "PUTAXIS",
@@ -1879,6 +1881,8 @@
         "OGOILSW",
         "OGSERVC",
         "PICKRTT",
+        "TRUCKPME",
+        "TRACPME",
         "PICKRTR",
         "RBTRLDR",
         "TLSCONV",
@@ -2031,6 +2035,8 @@
         "OGOILSW",
         "OGSERVC",
         "PICKRTT",
+        "TRUCKPME",
+        "TRACPME",
         "PICKRTR",
         "RBTRLDR",
         "TLSCONV",
@@ -2395,6 +2401,8 @@
         "OGSERVC",
         "OGSRRAH",
         "PICKRTT",
+        "TRUCKPME",
+        "TRACPME",
         "PLOWBLD",
         "PUTAXIS",
         "REGTRCK",
@@ -2550,6 +2558,8 @@
         "OGSERVC",
         "OGSRRAH",
         "PICKRTT",
+        "TRUCKPME",
+        "TRACPME",
         "PLOWBLD",
         "PUTAXIS",
         "REGTRCK",
@@ -2734,6 +2744,8 @@
         "OGSERVC",
         "OGSRRAH",
         "PICKRTT",
+        "TRUCKPME",
+        "TRACPME",
         "PLOWBLD",
         "PUTAXIS",
         "REGTRCK",
@@ -2907,6 +2919,8 @@
         "OGSERVC",
         "OGSRRAH",
         "PICKRTT",
+        "TRUCKPME",
+        "TRACPME",
         "PLOWBLD",
         "REGTRCK",
         "SCRAPER",
@@ -3095,6 +3109,8 @@
         "OGSERVC",
         "OGSRRAH",
         "PICKRTT",
+        "TRUCKPME",
+        "TRACPME",
         "PLOWBLD",
         "PUTAXIS",
         "REGTRCK",
@@ -3400,6 +3416,8 @@
         "OGSERVC",
         "OGSRRAH",
         "PICKRTT",
+        "TRUCKPME",
+        "TRACPME",
         "PLOWBLD",
         "PUTAXIS",
         "REGTRCK",
@@ -4041,6 +4059,22 @@
       {
         "id": "PICKRTT",
         "name": "Picker Truck Tractors",
+        "category": "powerunit",
+        "displayCodePrefix": "TT",
+        "displayCodeSteerAxle": "S",
+        "displayCodeDriveAxle": "D"
+      },
+      {
+        "id": "TRUCKPME",
+        "name": "Truck with PME",
+        "category": "powerunit",
+        "displayCodePrefix": "TT",
+        "displayCodeSteerAxle": "S",
+        "displayCodeDriveAxle": "D"
+      },
+      {
+        "id": "TRACPME",
+        "name": "Truck Tractor with PME",
         "category": "powerunit",
         "displayCodePrefix": "TT",
         "displayCodeSteerAxle": "S",
@@ -5208,6 +5242,192 @@
         },
         {
           "type": "PICKRTT",
+          "trailers": [
+            {
+              "type": "XXXXXXX",
+              "jeep": false,
+              "booster": false,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 1,
+                  "w": 2.6,
+                  "h": 4.15,
+                  "l": 16
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "STCRANE",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 2.6,
+                  "h": 4.15,
+                  "l": 25
+                }
+              ]
+            },
+            {
+              "type": "STROPRT",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 5,
+                  "h": 4.88,
+                  "l": 40,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ],
+              "weightPermittable": true,
+              "canAddAxleUnits": true
+            },
+            {
+              "type": "STRSELF",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 5,
+                  "h": 4.88,
+                  "l": 36,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ],
+              "weightPermittable": true,
+              "canAddAxleUnits": true
+            },
+            {
+              "type": "PLATWHE",
+              "jeep": true,
+              "booster": true,
+              "weightPermittable": true,
+              "canAddAxleUnits": true
+            }
+          ]
+        },
+        {
+          "type": "TRUCKPME",
+          "trailers": [
+            {
+              "type": "XXXXXXX",
+              "jeep": false,
+              "booster": false,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 1,
+                  "w": 2.6,
+                  "h": 4.15,
+                  "l": 16
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "STCRANE",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 2.6,
+                  "h": 4.15,
+                  "l": 25
+                }
+              ]
+            },
+            {
+              "type": "STROPRT",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 5,
+                  "h": 4.88,
+                  "l": 40,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ],
+              "weightPermittable": true,
+              "canAddAxleUnits": true
+            },
+            {
+              "type": "STRSELF",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 5,
+                  "h": 4.88,
+                  "l": 36,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ],
+              "weightPermittable": true,
+              "canAddAxleUnits": true
+            },
+            {
+              "type": "PLATWHE",
+              "jeep": true,
+              "booster": true,
+              "weightPermittable": true,
+              "canAddAxleUnits": true
+            }
+          ]
+        },
+        {
+          "type": "TRACPME",
           "trailers": [
             {
               "type": "XXXXXXX",
@@ -6772,6 +6992,192 @@
           ]
         },
         {
+          "type": "TRUCKPME",
+          "trailers": [
+            {
+              "type": "SEMITRL",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 3.2,
+                  "h": 4.3,
+                  "l": 27.5,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "HIBOEXP",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 3.2,
+                  "h": 4.3,
+                  "l": 27.5,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "HIBOFLT",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 3.2,
+                  "h": 4.3,
+                  "l": 27.5,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "STSDBDK",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 3.2,
+                  "h": 4.3,
+                  "l": 27.5,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "TRACPME",
+          "trailers": [
+            {
+              "type": "SEMITRL",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 3.2,
+                  "h": 4.3,
+                  "l": 27.5,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "HIBOEXP",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 3.2,
+                  "h": 4.3,
+                  "l": 27.5,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "HIBOFLT",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 3.2,
+                  "h": 4.3,
+                  "l": 27.5,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "STSDBDK",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 3.2,
+                  "h": 4.3,
+                  "l": 27.5,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
           "type": "STINGER",
           "trailers": [
             {
@@ -7415,6 +7821,286 @@
         },
         {
           "type": "PICKRTT",
+          "trailers": [
+            {
+              "type": "OGOSFDT",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 3.2,
+                  "h": 4.15,
+                  "l": 23
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "PLATFRM",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": false,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 3.2,
+                  "h": 4.15,
+                  "l": 27.5
+                }
+              ],
+              "weightPermittable": true,
+              "canAddAxleUnits": true
+            },
+            {
+              "type": "PLATWHE",
+              "jeep": true,
+              "booster": true,
+              "weightPermittable": true,
+              "canAddAxleUnits": true
+            },
+            {
+              "type": "HIBOEXP",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 2.6,
+                  "h": 4.15,
+                  "l": 25,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "l": 27.5
+                    }
+                  ]
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "STWHELR",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": false,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 3.2,
+                  "h": 4.15,
+                  "l": 27.5
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "STWIDWH",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": false,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 3.2,
+                  "h": 4.15,
+                  "l": 27.5
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "EXPANDO",
+              "jeep": false,
+              "booster": true,
+              "weightPermittable": true
+            },
+            {
+              "type": "SEMITRL",
+              "jeep": false,
+              "booster": true,
+              "weightPermittable": true
+            },
+            {
+              "type": "HIBOFLT",
+              "jeep": false,
+              "booster": true,
+              "weightPermittable": true
+            },
+            {
+              "type": "STSDBDK",
+              "jeep": false,
+              "booster": true,
+              "weightPermittable": true
+            },
+            {
+              "type": "STSTEER",
+              "jeep": false,
+              "booster": true,
+              "weightPermittable": true
+            },
+            {
+              "type": "STCRANE",
+              "jeep": false,
+              "booster": true,
+              "weightPermittable": true
+            }
+          ]
+        },
+        {
+          "type": "TRUCKPME",
+          "trailers": [
+            {
+              "type": "OGOSFDT",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 3.2,
+                  "h": 4.15,
+                  "l": 23
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "PLATFRM",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": false,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 3.2,
+                  "h": 4.15,
+                  "l": 27.5
+                }
+              ],
+              "weightPermittable": true,
+              "canAddAxleUnits": true
+            },
+            {
+              "type": "PLATWHE",
+              "jeep": true,
+              "booster": true,
+              "weightPermittable": true,
+              "canAddAxleUnits": true
+            },
+            {
+              "type": "HIBOEXP",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 2.6,
+                  "h": 4.15,
+                  "l": 25,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "l": 27.5
+                    }
+                  ]
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "STWHELR",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": false,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 3.2,
+                  "h": 4.15,
+                  "l": 27.5
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "STWIDWH",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": false,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 3.2,
+                  "h": 4.15,
+                  "l": 27.5
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "EXPANDO",
+              "jeep": false,
+              "booster": true,
+              "weightPermittable": true
+            },
+            {
+              "type": "SEMITRL",
+              "jeep": false,
+              "booster": true,
+              "weightPermittable": true
+            },
+            {
+              "type": "HIBOFLT",
+              "jeep": false,
+              "booster": true,
+              "weightPermittable": true
+            },
+            {
+              "type": "STSDBDK",
+              "jeep": false,
+              "booster": true,
+              "weightPermittable": true
+            },
+            {
+              "type": "STSTEER",
+              "jeep": false,
+              "booster": true,
+              "weightPermittable": true
+            },
+            {
+              "type": "STCRANE",
+              "jeep": false,
+              "booster": true,
+              "weightPermittable": true
+            }
+          ]
+        },
+        {
+          "type": "TRACPME",
           "trailers": [
             {
               "type": "OGOSFDT",
@@ -8421,6 +9107,526 @@
         },
         {
           "type": "PICKRTT",
+          "trailers": [
+            {
+              "type": "OGOSFDT",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": false,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 3.3,
+                  "h": 4.3,
+                  "l": 23
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "SEMITRL",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 5,
+                  "h": 4.88,
+                  "l": 25,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "HIBOEXP",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 5,
+                  "h": 4.4,
+                  "l": 25,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "HIBOFLT",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 5,
+                  "h": 4.4,
+                  "l": 25,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "STSDBDK",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": false,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 5,
+                  "h": 4.88,
+                  "l": 25,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "STSTEER",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 5,
+                  "h": 4.88,
+                  "l": 27.5,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "STWHELR",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": false,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 5,
+                  "h": 4.88,
+                  "l": 27.5,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "STCRANE",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 5,
+                  "h": 4.88,
+                  "l": 27.5,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "STROPRT",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 5,
+                  "h": 4.88,
+                  "l": 40,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ],
+              "canAddAxleUnits": true
+            },
+            {
+              "type": "STRSELF",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 5,
+                  "h": 4.88,
+                  "l": 36,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ],
+              "canAddAxleUnits": true
+            },
+            {
+              "type": "STWIDWH",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 5,
+                  "h": 4.88,
+                  "l": 27.5,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "PLATWHE",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "weightPermittable": true,
+              "canAddAxleUnits": true
+            }
+          ]
+        },
+        {
+          "type": "TRUCKPME",
+          "trailers": [
+            {
+              "type": "OGOSFDT",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": false,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 3.3,
+                  "h": 4.3,
+                  "l": 23
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "SEMITRL",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 5,
+                  "h": 4.88,
+                  "l": 25,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "HIBOEXP",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 5,
+                  "h": 4.4,
+                  "l": 25,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "HIBOFLT",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 5,
+                  "h": 4.4,
+                  "l": 25,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "STSDBDK",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": false,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 5,
+                  "h": 4.88,
+                  "l": 25,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "STSTEER",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 5,
+                  "h": 4.88,
+                  "l": 27.5,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "STWHELR",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": false,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 5,
+                  "h": 4.88,
+                  "l": 27.5,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "STCRANE",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 5,
+                  "h": 4.88,
+                  "l": 27.5,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "STROPRT",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 5,
+                  "h": 4.88,
+                  "l": 40,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ],
+              "canAddAxleUnits": true
+            },
+            {
+              "type": "STRSELF",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 5,
+                  "h": 4.88,
+                  "l": 36,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ],
+              "canAddAxleUnits": true
+            },
+            {
+              "type": "STWIDWH",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "sizePermittable": true,
+              "sizeDimensions": [
+                {
+                  "fp": 3,
+                  "rp": 6.5,
+                  "w": 5,
+                  "h": 4.88,
+                  "l": 27.5,
+                  "regions": [
+                    {
+                      "region": "PCE",
+                      "h": 5.33
+                    }
+                  ]
+                }
+              ],
+              "weightPermittable": true
+            },
+            {
+              "type": "PLATWHE",
+              "jeep": true,
+              "booster": true,
+              "selfIssue": true,
+              "weightPermittable": true,
+              "canAddAxleUnits": true
+            }
+          ]
+        },
+        {
+          "type": "TRACPME",
           "trailers": [
             {
               "type": "OGOSFDT",

--- a/src/_test/policy-config/_current-config.json
+++ b/src/_test/policy-config/_current-config.json
@@ -1530,7 +1530,7 @@
         "OGSRRAH",
         "PICKRTR",
         "PICKRTT",
-        "TRUCKPME",
+        "TRCKPME",
         "TRACPME",
         "RBTRLDR",
         "SCRAPER",
@@ -1881,7 +1881,7 @@
         "OGOILSW",
         "OGSERVC",
         "PICKRTT",
-        "TRUCKPME",
+        "TRCKPME",
         "TRACPME",
         "PICKRTR",
         "RBTRLDR",
@@ -2035,7 +2035,7 @@
         "OGOILSW",
         "OGSERVC",
         "PICKRTT",
-        "TRUCKPME",
+        "TRCKPME",
         "TRACPME",
         "PICKRTR",
         "RBTRLDR",
@@ -2401,7 +2401,7 @@
         "OGSERVC",
         "OGSRRAH",
         "PICKRTT",
-        "TRUCKPME",
+        "TRCKPME",
         "TRACPME",
         "PLOWBLD",
         "PUTAXIS",
@@ -2558,7 +2558,7 @@
         "OGSERVC",
         "OGSRRAH",
         "PICKRTT",
-        "TRUCKPME",
+        "TRCKPME",
         "TRACPME",
         "PLOWBLD",
         "PUTAXIS",
@@ -2744,7 +2744,7 @@
         "OGSERVC",
         "OGSRRAH",
         "PICKRTT",
-        "TRUCKPME",
+        "TRCKPME",
         "TRACPME",
         "PLOWBLD",
         "PUTAXIS",
@@ -2919,7 +2919,7 @@
         "OGSERVC",
         "OGSRRAH",
         "PICKRTT",
-        "TRUCKPME",
+        "TRCKPME",
         "TRACPME",
         "PLOWBLD",
         "REGTRCK",
@@ -3109,7 +3109,7 @@
         "OGSERVC",
         "OGSRRAH",
         "PICKRTT",
-        "TRUCKPME",
+        "TRCKPME",
         "TRACPME",
         "PLOWBLD",
         "PUTAXIS",
@@ -3416,7 +3416,7 @@
         "OGSERVC",
         "OGSRRAH",
         "PICKRTT",
-        "TRUCKPME",
+        "TRCKPME",
         "TRACPME",
         "PLOWBLD",
         "PUTAXIS",
@@ -4065,7 +4065,7 @@
         "displayCodeDriveAxle": "D"
       },
       {
-        "id": "TRUCKPME",
+        "id": "TRCKPME",
         "name": "Truck with PME",
         "category": "powerunit",
         "displayCodePrefix": "TT",
@@ -5334,7 +5334,7 @@
           ]
         },
         {
-          "type": "TRUCKPME",
+          "type": "TRCKPME",
           "trailers": [
             {
               "type": "XXXXXXX",
@@ -6992,7 +6992,7 @@
           ]
         },
         {
-          "type": "TRUCKPME",
+          "type": "TRCKPME",
           "trailers": [
             {
               "type": "SEMITRL",
@@ -7960,7 +7960,7 @@
           ]
         },
         {
-          "type": "TRUCKPME",
+          "type": "TRCKPME",
           "trailers": [
             {
               "type": "OGOSFDT",
@@ -9366,7 +9366,7 @@
           ]
         },
         {
-          "type": "TRUCKPME",
+          "type": "TRCKPME",
           "trailers": [
             {
               "type": "OGOSFDT",

--- a/src/_test/policy-config/_current-config.ts
+++ b/src/_test/policy-config/_current-config.ts
@@ -1534,6 +1534,8 @@ export const data: PolicyDefinition = {
         'OGSRRAH',
         'PICKRTR',
         'PICKRTT',
+        'TRUCKPME',
+        'TRACPME',
         'RBTRLDR',
         'SCRAPER',
         'PUTAXIS',
@@ -1894,6 +1896,8 @@ export const data: PolicyDefinition = {
         'OGOILSW',
         'OGSERVC',
         'PICKRTT',
+        'TRUCKPME',
+        'TRACPME',
         'PICKRTR',
         'RBTRLDR',
         'TLSCONV',
@@ -2046,6 +2050,8 @@ export const data: PolicyDefinition = {
         'OGOILSW',
         'OGSERVC',
         'PICKRTT',
+        'TRUCKPME',
+        'TRACPME',
         'PICKRTR',
         'RBTRLDR',
         'TLSCONV',
@@ -2408,6 +2414,8 @@ export const data: PolicyDefinition = {
         'OGSERVC',
         'OGSRRAH',
         'PICKRTT',
+        'TRUCKPME',
+        'TRACPME',
         'PLOWBLD',
         'PUTAXIS',
         'REGTRCK',
@@ -2528,6 +2536,8 @@ export const data: PolicyDefinition = {
         'OGSERVC',
         'OGSRRAH',
         'PICKRTT',
+        'TRUCKPME',
+        'TRACPME',
         'PLOWBLD',
         'PUTAXIS',
         'REGTRCK',
@@ -2712,6 +2722,8 @@ export const data: PolicyDefinition = {
         'OGSERVC',
         'OGSRRAH',
         'PICKRTT',
+        'TRUCKPME',
+        'TRACPME',
         'PLOWBLD',
         'PUTAXIS',
         'REGTRCK',
@@ -2886,6 +2898,8 @@ export const data: PolicyDefinition = {
         'OGSERVC',
         'OGSRRAH',
         'PICKRTT',
+        'TRUCKPME',
+        'TRACPME',
         'PLOWBLD',
         'REGTRCK',
         'SCRAPER',
@@ -3075,6 +3089,8 @@ export const data: PolicyDefinition = {
         'OGSERVC',
         'OGSRRAH',
         'PICKRTT',
+        'TRUCKPME',
+        'TRACPME',
         'PLOWBLD',
         'PUTAXIS',
         'REGTRCK',
@@ -3382,6 +3398,8 @@ export const data: PolicyDefinition = {
         'OGSERVC',
         'OGSRRAH',
         'PICKRTT',
+        'TRUCKPME',
+        'TRACPME',
         'PLOWBLD',
         'PUTAXIS',
         'REGTRCK',
@@ -4026,6 +4044,22 @@ export const data: PolicyDefinition = {
       {
         id: 'PICKRTT',
         name: 'Picker Truck Tractors',
+        category: 'powerunit',
+        displayCodePrefix: 'TT',
+        displayCodeSteerAxle: 'S',
+        displayCodeDriveAxle: 'D',
+      },
+      {
+        id: 'TRUCKPME',
+        name: 'Truck with PME',
+        category: 'powerunit',
+        displayCodePrefix: 'TT',
+        displayCodeSteerAxle: 'S',
+        displayCodeDriveAxle: 'D',
+      },
+      {
+        id: 'TRACPME',
+        name: 'Truck Tractor with PME',
         category: 'powerunit',
         displayCodePrefix: 'TT',
         displayCodeSteerAxle: 'S',
@@ -5159,6 +5193,174 @@ export const data: PolicyDefinition = {
         },
         {
           type: 'PICKRTT',
+          trailers: [
+            {
+              type: 'XXXXXXX',
+              jeep: false,
+              booster: false,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 1,
+                  w: 2.6,
+                  h: 4.15,
+                  l: 16,
+                },
+              ],
+              weightPermittable: true,
+            },
+            {
+              type: 'STCRANE',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 2.6,
+                  h: 4.15,
+                  l: 25,
+                },
+              ],
+            },
+            {
+              type: 'STROPRT',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 5,
+                  h: 4.88,
+                  l: 40,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+              weightPermittable: true,
+            },
+            {
+              type: 'STRSELF',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 5,
+                  h: 4.88,
+                  l: 36,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+              weightPermittable: true,
+            },
+          ],
+        },
+        {
+          type: 'TRUCKPME',
+          trailers: [
+            {
+              type: 'XXXXXXX',
+              jeep: false,
+              booster: false,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 1,
+                  w: 2.6,
+                  h: 4.15,
+                  l: 16,
+                },
+              ],
+              weightPermittable: true,
+            },
+            {
+              type: 'STCRANE',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 2.6,
+                  h: 4.15,
+                  l: 25,
+                },
+              ],
+            },
+            {
+              type: 'STROPRT',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 5,
+                  h: 4.88,
+                  l: 40,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+              weightPermittable: true,
+            },
+            {
+              type: 'STRSELF',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 5,
+                  h: 4.88,
+                  l: 36,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+              weightPermittable: true,
+            },
+          ],
+        },
+        {
+          type: 'TRACPME',
           trailers: [
             {
               type: 'XXXXXXX',
@@ -6679,6 +6881,192 @@ export const data: PolicyDefinition = {
           ],
         },
         {
+          type: 'TRUCKPME',
+          trailers: [
+            {
+              type: 'SEMITRL',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 3.2,
+                  h: 4.3,
+                  l: 27.5,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'HIBOEXP',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 3.2,
+                  h: 4.3,
+                  l: 27.5,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'HIBOFLT',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 3.2,
+                  h: 4.3,
+                  l: 27.5,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'STSDBDK',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 3.2,
+                  h: 4.3,
+                  l: 27.5,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'TRACPME',
+          trailers: [
+            {
+              type: 'SEMITRL',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 3.2,
+                  h: 4.3,
+                  l: 27.5,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'HIBOEXP',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 3.2,
+                  h: 4.3,
+                  l: 27.5,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'HIBOFLT',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 3.2,
+                  h: 4.3,
+                  l: 27.5,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'STSDBDK',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 3.2,
+                  h: 4.3,
+                  l: 27.5,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
           type: 'STINGER',
           trailers: [
             {
@@ -7281,6 +7669,190 @@ export const data: PolicyDefinition = {
         },
         {
           type: 'PICKRTT',
+          trailers: [
+            {
+              type: 'OGOSFDT',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 3.2,
+                  h: 4.15,
+                  l: 23,
+                },
+              ],
+            },
+            {
+              type: 'PLATFRM',
+              jeep: true,
+              booster: true,
+              selfIssue: false,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 3.2,
+                  h: 4.15,
+                  l: 27.5,
+                },
+              ],
+              weightPermittable: true,
+            },
+            {
+              type: 'HIBOEXP',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 2.6,
+                  h: 4.15,
+                  l: 25,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      l: 27.5,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'STWHELR',
+              jeep: true,
+              booster: true,
+              selfIssue: false,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 3.2,
+                  h: 4.15,
+                  l: 27.5,
+                },
+              ],
+            },
+            {
+              type: 'STWIDWH',
+              jeep: true,
+              booster: true,
+              selfIssue: false,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 3.2,
+                  h: 4.15,
+                  l: 27.5,
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'TRUCKPME',
+          trailers: [
+            {
+              type: 'OGOSFDT',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 3.2,
+                  h: 4.15,
+                  l: 23,
+                },
+              ],
+            },
+            {
+              type: 'PLATFRM',
+              jeep: true,
+              booster: true,
+              selfIssue: false,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 3.2,
+                  h: 4.15,
+                  l: 27.5,
+                },
+              ],
+              weightPermittable: true,
+            },
+            {
+              type: 'HIBOEXP',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 2.6,
+                  h: 4.15,
+                  l: 25,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      l: 27.5,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'STWHELR',
+              jeep: true,
+              booster: true,
+              selfIssue: false,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 3.2,
+                  h: 4.15,
+                  l: 27.5,
+                },
+              ],
+            },
+            {
+              type: 'STWIDWH',
+              jeep: true,
+              booster: true,
+              selfIssue: false,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 3.2,
+                  h: 4.15,
+                  l: 27.5,
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'TRACPME',
           trailers: [
             {
               type: 'OGOSFDT',
@@ -8220,6 +8792,492 @@ export const data: PolicyDefinition = {
         },
         {
           type: 'PICKRTT',
+          trailers: [
+            {
+              type: 'OGOSFDT',
+              jeep: true,
+              booster: true,
+              selfIssue: false,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 3.3,
+                  h: 4.3,
+                  l: 23,
+                },
+              ],
+              weightPermittable: true,
+            },
+            {
+              type: 'SEMITRL',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 5,
+                  h: 4.88,
+                  l: 25,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+              weightPermittable: true,
+            },
+            {
+              type: 'HIBOEXP',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 5,
+                  h: 4.4,
+                  l: 25,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'HIBOFLT',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 5,
+                  h: 4.4,
+                  l: 25,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'STSDBDK',
+              jeep: true,
+              booster: true,
+              selfIssue: false,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 5,
+                  h: 4.88,
+                  l: 25,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'STSTEER',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 5,
+                  h: 4.88,
+                  l: 27.5,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'STWHELR',
+              jeep: true,
+              booster: true,
+              selfIssue: false,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 5,
+                  h: 4.88,
+                  l: 27.5,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'STCRANE',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 5,
+                  h: 4.88,
+                  l: 27.5,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'STROPRT',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 5,
+                  h: 4.88,
+                  l: 40,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'STRSELF',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 5,
+                  h: 4.88,
+                  l: 36,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'STWIDWH',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 5,
+                  h: 4.88,
+                  l: 27.5,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'TRUCKPME',
+          trailers: [
+            {
+              type: 'OGOSFDT',
+              jeep: true,
+              booster: true,
+              selfIssue: false,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 3.3,
+                  h: 4.3,
+                  l: 23,
+                },
+              ],
+              weightPermittable: true,
+            },
+            {
+              type: 'SEMITRL',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 5,
+                  h: 4.88,
+                  l: 25,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+              weightPermittable: true,
+            },
+            {
+              type: 'HIBOEXP',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 5,
+                  h: 4.4,
+                  l: 25,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'HIBOFLT',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 5,
+                  h: 4.4,
+                  l: 25,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'STSDBDK',
+              jeep: true,
+              booster: true,
+              selfIssue: false,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 5,
+                  h: 4.88,
+                  l: 25,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'STSTEER',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 5,
+                  h: 4.88,
+                  l: 27.5,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'STWHELR',
+              jeep: true,
+              booster: true,
+              selfIssue: false,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 5,
+                  h: 4.88,
+                  l: 27.5,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'STCRANE',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 5,
+                  h: 4.88,
+                  l: 27.5,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'STROPRT',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 5,
+                  h: 4.88,
+                  l: 40,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'STRSELF',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 5,
+                  h: 4.88,
+                  l: 36,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'STWIDWH',
+              jeep: true,
+              booster: true,
+              selfIssue: true,
+              sizePermittable: true,
+              sizeDimensions: [
+                {
+                  fp: 3,
+                  rp: 6.5,
+                  w: 5,
+                  h: 4.88,
+                  l: 27.5,
+                  regions: [
+                    {
+                      region: 'PCE',
+                      h: 5.33,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'TRACPME',
           trailers: [
             {
               type: 'OGOSFDT',

--- a/src/_test/policy-config/_current-config.ts
+++ b/src/_test/policy-config/_current-config.ts
@@ -1534,7 +1534,7 @@ export const data: PolicyDefinition = {
         'OGSRRAH',
         'PICKRTR',
         'PICKRTT',
-        'TRUCKPME',
+        'TRCKPME',
         'TRACPME',
         'RBTRLDR',
         'SCRAPER',
@@ -1896,7 +1896,7 @@ export const data: PolicyDefinition = {
         'OGOILSW',
         'OGSERVC',
         'PICKRTT',
-        'TRUCKPME',
+        'TRCKPME',
         'TRACPME',
         'PICKRTR',
         'RBTRLDR',
@@ -2050,7 +2050,7 @@ export const data: PolicyDefinition = {
         'OGOILSW',
         'OGSERVC',
         'PICKRTT',
-        'TRUCKPME',
+        'TRCKPME',
         'TRACPME',
         'PICKRTR',
         'RBTRLDR',
@@ -2414,7 +2414,7 @@ export const data: PolicyDefinition = {
         'OGSERVC',
         'OGSRRAH',
         'PICKRTT',
-        'TRUCKPME',
+        'TRCKPME',
         'TRACPME',
         'PLOWBLD',
         'PUTAXIS',
@@ -2536,7 +2536,7 @@ export const data: PolicyDefinition = {
         'OGSERVC',
         'OGSRRAH',
         'PICKRTT',
-        'TRUCKPME',
+        'TRCKPME',
         'TRACPME',
         'PLOWBLD',
         'PUTAXIS',
@@ -2722,7 +2722,7 @@ export const data: PolicyDefinition = {
         'OGSERVC',
         'OGSRRAH',
         'PICKRTT',
-        'TRUCKPME',
+        'TRCKPME',
         'TRACPME',
         'PLOWBLD',
         'PUTAXIS',
@@ -2898,7 +2898,7 @@ export const data: PolicyDefinition = {
         'OGSERVC',
         'OGSRRAH',
         'PICKRTT',
-        'TRUCKPME',
+        'TRCKPME',
         'TRACPME',
         'PLOWBLD',
         'REGTRCK',
@@ -3089,7 +3089,7 @@ export const data: PolicyDefinition = {
         'OGSERVC',
         'OGSRRAH',
         'PICKRTT',
-        'TRUCKPME',
+        'TRCKPME',
         'TRACPME',
         'PLOWBLD',
         'PUTAXIS',
@@ -3398,7 +3398,7 @@ export const data: PolicyDefinition = {
         'OGSERVC',
         'OGSRRAH',
         'PICKRTT',
-        'TRUCKPME',
+        'TRCKPME',
         'TRACPME',
         'PLOWBLD',
         'PUTAXIS',
@@ -4050,7 +4050,7 @@ export const data: PolicyDefinition = {
         displayCodeDriveAxle: 'D',
       },
       {
-        id: 'TRUCKPME',
+        id: 'TRCKPME',
         name: 'Truck with PME',
         category: 'powerunit',
         displayCodePrefix: 'TT',
@@ -5276,7 +5276,7 @@ export const data: PolicyDefinition = {
           ],
         },
         {
-          type: 'TRUCKPME',
+          type: 'TRCKPME',
           trailers: [
             {
               type: 'XXXXXXX',
@@ -6881,7 +6881,7 @@ export const data: PolicyDefinition = {
           ],
         },
         {
-          type: 'TRUCKPME',
+          type: 'TRCKPME',
           trailers: [
             {
               type: 'SEMITRL',
@@ -7760,7 +7760,7 @@ export const data: PolicyDefinition = {
           ],
         },
         {
-          type: 'TRUCKPME',
+          type: 'TRCKPME',
           trailers: [
             {
               type: 'OGOSFDT',
@@ -9034,7 +9034,7 @@ export const data: PolicyDefinition = {
           ],
         },
         {
-          type: 'TRUCKPME',
+          type: 'TRCKPME',
           trailers: [
             {
               type: 'OGOSFDT',

--- a/src/_test/unit/axle-calc.spec.ts
+++ b/src/_test/unit/axle-calc.spec.ts
@@ -58,6 +58,7 @@ describe('Axle Calculation Functions', () => {
     p.permitData.vehicleDetails.vehicleSubType = 'TRKTRAC';
     p.permitData.vehicleConfiguration.axleConfiguration =
       getTruckTractorWheelbaseAxles(interaxleSpacing, axleSpread);
+    p.permitData.vehicleConfiguration.axleConfiguration[0].axleUnitWeight = 6000;
     return p;
   };
 
@@ -883,9 +884,13 @@ describe('Axle Calculation Functions', () => {
   });
 
   it('should return no failing policy checks for valid STOW', async () => {
+    const legalAxleConfiguration = JSON.parse(
+      JSON.stringify(axleConfiguration),
+    ) as Array<AxleConfiguration>;
+    legalAxleConfiguration[0].axleUnitWeight = 6000;
     const results = policy.runAxleCalculation(
       vehicleConfiguration,
-      axleConfiguration,
+      legalAxleConfiguration,
       0,
     );
     expect(

--- a/src/_test/unit/axle-group-legal-weight.spec.ts
+++ b/src/_test/unit/axle-group-legal-weight.spec.ts
@@ -443,6 +443,7 @@ describe('ORV2-5617 axle group maximum legal weight threshold', () => {
       );
       const axleConfiguration =
         permit.permitData.vehicleConfiguration.axleConfiguration;
+      axleConfiguration[0].axleUnitWeight = 6000;
       axleConfiguration[1].axleUnitWeight = driveWeight;
       axleConfiguration[1].numberOfTires = 8;
       axleConfiguration[2] = {
@@ -468,7 +469,7 @@ describe('ORV2-5617 axle group maximum legal weight threshold', () => {
 
     it('exposes a nested trailer failure through validate details and structured results', async () => {
       const validationResult = await policy.validate(
-        getNestedJeepPermit(13500, 10501),
+        getNestedJeepPermit(14900, 9101),
       );
       const failure = validationResult.axleCalculationResults?.results.find(
         (result) =>
@@ -498,7 +499,7 @@ describe('ORV2-5617 axle group maximum legal weight threshold', () => {
 
     it('does not add an axle-calculation violation at the exact threshold', async () => {
       const validationResult = await policy.validate(
-        getNestedJeepPermit(13500, 10500),
+        getNestedJeepPermit(14900, 9100),
       );
       const axleCalculationViolation = validationResult.violations.find(
         (violation) =>

--- a/src/_test/unit/configuration.spec.ts
+++ b/src/_test/unit/configuration.spec.ts
@@ -8,10 +8,12 @@ describe('Policy Engine Oversize Configuration Functions', () => {
 
   it('should retrieve all permittable power unit types for STOS', async () => {
     const puTypes = policy.getPermittablePowerUnitTypes('STOS', 'EMPTYXX');
-    expect(puTypes.size).toBe(3);
+    expect(puTypes.size).toBe(5);
     expect(puTypes.keys()).toContain('TRKTRAC');
     expect(puTypes.keys()).toContain('PICKRTT');
     expect(puTypes.keys()).toContain('PICKRTR');
+    expect(puTypes.keys()).toContain('TRUCKPME');
+    expect(puTypes.keys()).toContain('TRACPME');
   });
 
   it('should retrieve valid power unit types for STOW', async () => {

--- a/src/_test/unit/configuration.spec.ts
+++ b/src/_test/unit/configuration.spec.ts
@@ -12,7 +12,7 @@ describe('Policy Engine Oversize Configuration Functions', () => {
     expect(puTypes.keys()).toContain('TRKTRAC');
     expect(puTypes.keys()).toContain('PICKRTT');
     expect(puTypes.keys()).toContain('PICKRTR');
-    expect(puTypes.keys()).toContain('TRUCKPME');
+    expect(puTypes.keys()).toContain('TRCKPME');
     expect(puTypes.keys()).toContain('TRACPME');
   });
 

--- a/src/_test/unit/legal-weight-maximum.spec.ts
+++ b/src/_test/unit/legal-weight-maximum.spec.ts
@@ -1,0 +1,339 @@
+import { Policy } from '../../policy-engine';
+import { PolicyCheckId, PolicyCheckResultType } from '../../enum/policy-check';
+import { AxleConfiguration } from '../../types';
+import currentPolicyConfig from '../policy-config/_current-config.json';
+
+describe('ORV2-5706 legal weight maximums', () => {
+  const policy = new Policy(currentPolicyConfig);
+
+  const getLegalResult = (
+    powerUnitType: string,
+    steerAxleCount: number,
+    driveAxleCount: number,
+    axleUnit: 1 | 2,
+    actualWeight: number,
+  ) => {
+    const axleConfiguration: Array<AxleConfiguration> = [
+      {
+        numberOfAxles: steerAxleCount,
+        axleSpread: steerAxleCount > 1 ? 160 : undefined,
+        axleUnitWeight: axleUnit === 1 ? actualWeight : 6000,
+        numberOfTires: steerAxleCount * 2,
+        tireSize: 455,
+        vehicleIndex: 0,
+      },
+      {
+        numberOfAxles: driveAxleCount,
+        axleSpread: driveAxleCount > 1 ? 160 : undefined,
+        interaxleSpacing: 500,
+        axleUnitWeight: axleUnit === 2 ? actualWeight : 12000,
+        numberOfTires: driveAxleCount * 4,
+        tireSize: 455,
+        vehicleIndex: 0,
+      },
+    ];
+
+    return policy
+      .runAxleCalculation([powerUnitType], axleConfiguration, 100000)
+      .results.find(
+        (result) =>
+          result.id === PolicyCheckId.CheckLegalWeight &&
+          result.startAxleUnit === axleUnit,
+      )!;
+  };
+
+  const expectLegalResult = (
+    result: ReturnType<typeof getLegalResult>,
+    thresholdWeight: number,
+    expectedResult: PolicyCheckResultType,
+  ) => {
+    expect(result).toMatchObject({
+      thresholdWeight,
+      result: expectedResult,
+      actualWeight: result.actualWeight,
+    });
+  };
+
+  // Source: ASW Legal Weight Maximums.feature @orv2-5706-1.
+  describe('steering maximums from configuration inputs', () => {
+    it.each([
+      ['REGTRCK', 1, 2, 9100],
+      ['TRKTRAC', 1, 2, 6000],
+      ['TRUCKPME', 1, 3, 9100],
+      ['TRKTRAC', 2, 2, 17000],
+      ['TRACPME', 2, 3, 15200],
+    ])(
+      'uses the feature threshold for %s with %i steer and %i drive axles (%i kg)',
+      (powerUnitType, steerAxleCount, driveAxleCount, thresholdWeight) => {
+        expectLegalResult(
+          getLegalResult(
+            powerUnitType as string,
+            steerAxleCount as number,
+            driveAxleCount as number,
+            1,
+            thresholdWeight as number,
+          ),
+          thresholdWeight as number,
+          PolicyCheckResultType.Pass,
+        );
+      },
+    );
+  });
+
+  // Source: ASW Legal Weight Maximums.feature @orv2-5706-2.
+  describe('single steer with single or tandem drive', () => {
+    it.each([
+      ['REGTRCK', 1, 9100, 9100, PolicyCheckResultType.Pass],
+      ['TRKTRAC', 2, 6001, 6000, PolicyCheckResultType.Fail],
+      ['TRACPME', 2, 9100, 9100, PolicyCheckResultType.Pass],
+    ])(
+      'evaluates %s with %i drive axles at %i kg',
+      (
+        powerUnitType,
+        driveAxleCount,
+        actualWeight,
+        thresholdWeight,
+        expectedResult,
+      ) => {
+        expectLegalResult(
+          getLegalResult(
+            powerUnitType as string,
+            1,
+            driveAxleCount as number,
+            1,
+            actualWeight as number,
+          ),
+          thresholdWeight as number,
+          expectedResult as PolicyCheckResultType,
+        );
+      },
+    );
+  });
+
+  // Source: ASW Legal Weight Maximums.feature @orv2-5706-3.
+  describe('single steer with tridem drive', () => {
+    it.each([
+      ['TRKTRAC', 7300, 7300, PolicyCheckResultType.Pass],
+      ['REGTRCK', 7301, 7300, PolicyCheckResultType.Fail],
+      ['TRUCKPME', 9100, 9100, PolicyCheckResultType.Pass],
+    ])(
+      'evaluates %s at %i kg',
+      (powerUnitType, actualWeight, thresholdWeight, expectedResult) => {
+        expectLegalResult(
+          getLegalResult(
+            powerUnitType as string,
+            1,
+            3,
+            1,
+            actualWeight as number,
+          ),
+          thresholdWeight as number,
+          expectedResult as PolicyCheckResultType,
+        );
+      },
+    );
+  });
+
+  // Source: ASW Legal Weight Maximums.feature @orv2-5706-4.
+  describe('tandem steer with tandem drive', () => {
+    it.each([
+      ['TRKTRAC', 17000, PolicyCheckResultType.Pass],
+      ['TRUCKPME', 17001, PolicyCheckResultType.Fail],
+    ])(
+      'evaluates %s at %i kg',
+      (powerUnitType, actualWeight, expectedResult) => {
+        expectLegalResult(
+          getLegalResult(
+            powerUnitType as string,
+            2,
+            2,
+            1,
+            actualWeight as number,
+          ),
+          17000,
+          expectedResult as PolicyCheckResultType,
+        );
+      },
+    );
+  });
+
+  // Source: ASW Legal Weight Maximums.feature @orv2-5706-5.
+  describe('tandem steer with tridem drive', () => {
+    it.each([
+      ['TRKTRAC', 13600, 13600, PolicyCheckResultType.Pass],
+      ['REGTRCK', 13601, 13600, PolicyCheckResultType.Fail],
+      ['TRACPME', 15200, 15200, PolicyCheckResultType.Pass],
+    ])(
+      'evaluates %s at %i kg',
+      (powerUnitType, actualWeight, thresholdWeight, expectedResult) => {
+        expectLegalResult(
+          getLegalResult(
+            powerUnitType as string,
+            2,
+            3,
+            1,
+            actualWeight as number,
+          ),
+          thresholdWeight as number,
+          expectedResult as PolicyCheckResultType,
+        );
+      },
+    );
+  });
+
+  // Source: ASW Legal Weight Maximums.feature @orv2-5706-7.
+  describe('drive maximums from configuration inputs', () => {
+    it.each([
+      ['REGTRCK', 1, 9100],
+      ['TRACPME', 2, 17000],
+      ['REGTRCK', 3, 24000],
+      ['TRKTRAC', 3, 24000],
+    ])(
+      'uses the feature threshold for %s with %i drive axles (%i kg)',
+      (powerUnitType, driveAxleCount, thresholdWeight) => {
+        expectLegalResult(
+          getLegalResult(
+            powerUnitType as string,
+            1,
+            driveAxleCount as number,
+            2,
+            thresholdWeight as number,
+          ),
+          thresholdWeight as number,
+          PolicyCheckResultType.Pass,
+        );
+      },
+    );
+  });
+
+  // Source: ASW Legal Weight Maximums.feature @orv2-5706-8.
+  describe('single drive boundary', () => {
+    it.each([
+      [9100, PolicyCheckResultType.Pass],
+      [9101, PolicyCheckResultType.Fail],
+    ])('evaluates %i kg', (actualWeight, expectedResult) => {
+      expectLegalResult(
+        getLegalResult('REGTRCK', 1, 1, 2, actualWeight),
+        9100,
+        expectedResult,
+      );
+    });
+  });
+
+  // Source: ASW Legal Weight Maximums.feature @orv2-5706-9.
+  describe('tandem drive boundary', () => {
+    it.each([
+      [17000, PolicyCheckResultType.Pass],
+      [17001, PolicyCheckResultType.Fail],
+    ])('evaluates %i kg', (actualWeight, expectedResult) => {
+      expectLegalResult(
+        getLegalResult('TRKTRAC', 1, 2, 2, actualWeight),
+        17000,
+        expectedResult,
+      );
+    });
+  });
+
+  // Source: ASW Legal Weight Maximums.feature @orv2-5706-10.
+  describe('fixed-load tridem drive boundary', () => {
+    it.each([
+      [24000, PolicyCheckResultType.Pass],
+      [24001, PolicyCheckResultType.Fail],
+    ])('evaluates %i kg', (actualWeight, expectedResult) => {
+      expectLegalResult(
+        getLegalResult('REGTRCK', 1, 3, 2, actualWeight),
+        24000,
+        expectedResult,
+      );
+    });
+  });
+
+  // Source: ASW Legal Weight Maximums.feature @orv2-5706-11.
+  describe('truck-tractor tridem drive boundary', () => {
+    it.each([
+      [24000, PolicyCheckResultType.Pass],
+      [24001, PolicyCheckResultType.Fail],
+    ])('evaluates %i kg', (actualWeight, expectedResult) => {
+      expectLegalResult(
+        getLegalResult('TRKTRAC', 1, 3, 2, actualWeight),
+        24000,
+        expectedResult,
+      );
+    });
+  });
+
+  it('returns one structured result for every axle unit', () => {
+    const axleConfiguration: Array<AxleConfiguration> = [
+      {
+        numberOfAxles: 1,
+        axleUnitWeight: 9100,
+        vehicleIndex: 0,
+      },
+      {
+        numberOfAxles: 2,
+        axleSpread: 160,
+        interaxleSpacing: 500,
+        axleUnitWeight: 17000,
+        vehicleIndex: 0,
+      },
+      {
+        numberOfAxles: 1,
+        interaxleSpacing: 500,
+        axleUnitWeight: 9100,
+        vehicleIndex: 1,
+      },
+    ];
+    const results = policy
+      .runAxleCalculation(['TRUCKPME', 'SEMITRL'], axleConfiguration, 100000)
+      .results.filter((result) => result.id === PolicyCheckId.CheckLegalWeight);
+
+    expect(results).toHaveLength(axleConfiguration.length);
+    expect(results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          startAxleUnit: 1,
+          endAxleUnit: 1,
+          actualWeight: 9100,
+          thresholdWeight: 9100,
+        }),
+        expect.objectContaining({
+          startAxleUnit: 3,
+          endAxleUnit: 3,
+          actualWeight: 9100,
+          thresholdWeight: 9100,
+        }),
+      ]),
+    );
+  });
+
+  it('retains configured legal lookup for unrelated power units and trailers', () => {
+    const axleConfiguration: Array<AxleConfiguration> = [
+      {
+        numberOfAxles: 1,
+        axleUnitWeight: 6000,
+        vehicleIndex: 0,
+      },
+      {
+        numberOfAxles: 2,
+        axleSpread: 160,
+        interaxleSpacing: 500,
+        axleUnitWeight: 17000,
+        vehicleIndex: 0,
+      },
+      {
+        numberOfAxles: 2,
+        axleSpread: 160,
+        interaxleSpacing: 500,
+        axleUnitWeight: 17000,
+        vehicleIndex: 1,
+      },
+    ];
+    const results = policy
+      .runAxleCalculation(['CONCRET', 'SEMITRL'], axleConfiguration, 100000)
+      .results.filter((result) => result.id === PolicyCheckId.CheckLegalWeight);
+
+    expect(results.map(({ thresholdWeight }) => thresholdWeight)).toEqual([
+      9100, 17000, 17000,
+    ]);
+  });
+});

--- a/src/_test/unit/legal-weight-maximum.spec.ts
+++ b/src/_test/unit/legal-weight-maximum.spec.ts
@@ -59,7 +59,7 @@ describe('ORV2-5706 legal weight maximums', () => {
     it.each([
       ['REGTRCK', 1, 2, 9100],
       ['TRKTRAC', 1, 2, 6000],
-      ['TRUCKPME', 1, 3, 9100],
+      ['TRCKPME', 1, 3, 9100],
       ['TRKTRAC', 2, 2, 17000],
       ['TRACPME', 2, 3, 15200],
     ])(
@@ -115,7 +115,7 @@ describe('ORV2-5706 legal weight maximums', () => {
     it.each([
       ['TRKTRAC', 7300, 7300, PolicyCheckResultType.Pass],
       ['REGTRCK', 7301, 7300, PolicyCheckResultType.Fail],
-      ['TRUCKPME', 9100, 9100, PolicyCheckResultType.Pass],
+      ['TRCKPME', 9100, 9100, PolicyCheckResultType.Pass],
     ])(
       'evaluates %s at %i kg',
       (powerUnitType, actualWeight, thresholdWeight, expectedResult) => {
@@ -138,7 +138,7 @@ describe('ORV2-5706 legal weight maximums', () => {
   describe('tandem steer with tandem drive', () => {
     it.each([
       ['TRKTRAC', 17000, PolicyCheckResultType.Pass],
-      ['TRUCKPME', 17001, PolicyCheckResultType.Fail],
+      ['TRCKPME', 17001, PolicyCheckResultType.Fail],
     ])(
       'evaluates %s at %i kg',
       (powerUnitType, actualWeight, expectedResult) => {
@@ -284,7 +284,7 @@ describe('ORV2-5706 legal weight maximums', () => {
       },
     ];
     const results = policy
-      .runAxleCalculation(['TRUCKPME', 'SEMITRL'], axleConfiguration, 100000)
+      .runAxleCalculation(['TRCKPME', 'SEMITRL'], axleConfiguration, 100000)
       .results.filter((result) => result.id === PolicyCheckId.CheckLegalWeight);
 
     expect(results).toHaveLength(axleConfiguration.length);

--- a/src/_test/unit/multi-axle.spec.ts
+++ b/src/_test/unit/multi-axle.spec.ts
@@ -78,11 +78,11 @@ describe('Multi-Axle Unit Calculation Tests', () => {
         }),
         expect.objectContaining({
           id: PolicyCheckId.CheckPermittableWeight,
-          result: PolicyCheckResultType.Fail,
+          result: PolicyCheckResultType.Pass,
           startAxleUnit: 2,
           endAxleUnit: 2,
           actualWeight: 2000,
-          thresholdWeight: 0,
+          thresholdWeight: 11000,
         }),
       ]),
     );
@@ -154,7 +154,7 @@ describe('Multi-Axle Unit Calculation Tests', () => {
           startAxleUnit: 3,
           endAxleUnit: 3,
           actualWeight: 5000,
-          thresholdWeight: 29000,
+          thresholdWeight: 28000,
         }),
       ]),
     );

--- a/src/_test/unit/multi-axle.spec.ts
+++ b/src/_test/unit/multi-axle.spec.ts
@@ -37,7 +37,7 @@ describe('Multi-Axle Unit Calculation Tests', () => {
     ).toBe(true);
   });
 
-  it('should return policy results for a concrete truck with unsupported tandem steer and single drive weights', () => {
+  it('should preserve unsupported tandem-steer configuration while applying the single non-steering maximum', () => {
     let results: AxleCalcResults | undefined;
 
     expect(() => {

--- a/src/_test/unit/permittable-weight-maximum.spec.ts
+++ b/src/_test/unit/permittable-weight-maximum.spec.ts
@@ -1,0 +1,439 @@
+import { Policy } from '../../policy-engine';
+import { PolicyCheckId, PolicyCheckResultType } from '../../enum/policy-check';
+import { AxleConfiguration, PolicyDefinition } from '../../types';
+import currentPolicyConfig from '../policy-config/_current-config.json';
+
+describe('ORV2-5709 permittable weight maximums', () => {
+  const policy = new Policy(currentPolicyConfig);
+
+  type Scenario = {
+    axleUnit: 1 | 2 | 3;
+    axleCount: number;
+    actualWeight: number;
+    spread?: number;
+    boosterAxleCount?: number;
+  };
+
+  const getPermittableResult = ({
+    axleUnit,
+    axleCount,
+    actualWeight,
+    spread,
+    boosterAxleCount,
+  }: Scenario) => {
+    const hasTrailer = axleUnit === 3;
+    const hasBooster = boosterAxleCount !== undefined;
+    const vehicleConfiguration = [
+      'TRKTRAC',
+      ...(hasTrailer ? ['SEMITRL'] : []),
+      ...(hasBooster ? ['BOOSTER'] : []),
+    ];
+    const axleConfiguration: Array<AxleConfiguration> = [
+      {
+        numberOfAxles: axleUnit === 1 ? axleCount : 1,
+        axleSpread:
+          axleUnit === 1 && axleCount > 1 ? (spread ?? 160) : undefined,
+        axleUnitWeight: axleUnit === 1 ? actualWeight : 6000,
+        numberOfTires: (axleUnit === 1 ? axleCount : 1) * 2,
+        tireSize: 455,
+        vehicleIndex: 0,
+      },
+      {
+        numberOfAxles: axleUnit === 2 ? axleCount : 2,
+        axleSpread:
+          axleUnit === 2 ? (axleCount > 1 ? (spread ?? 160) : undefined) : 160,
+        interaxleSpacing: 500,
+        axleUnitWeight: axleUnit === 2 ? actualWeight : 17000,
+        numberOfTires: (axleUnit === 2 ? axleCount : 2) * 4,
+        tireSize: 455,
+        vehicleIndex: 0,
+      },
+    ];
+
+    if (hasTrailer) {
+      axleConfiguration.push({
+        numberOfAxles: axleCount,
+        axleSpread: axleCount > 1 ? spread : undefined,
+        interaxleSpacing: 500,
+        axleUnitWeight: actualWeight,
+        numberOfTires: axleCount * 4,
+        tireSize: 455,
+        vehicleIndex: 1,
+      });
+    }
+    if (hasBooster) {
+      axleConfiguration.push({
+        numberOfAxles: boosterAxleCount,
+        axleSpread: boosterAxleCount > 1 ? 160 : undefined,
+        interaxleSpacing: 500,
+        axleUnitWeight: 10000,
+        numberOfTires: boosterAxleCount * 4,
+        tireSize: 455,
+        vehicleIndex: 2,
+      });
+    }
+
+    return policy
+      .runAxleCalculation(vehicleConfiguration, axleConfiguration, 100000)
+      .results.find(
+        (result) =>
+          result.id === PolicyCheckId.CheckPermittableWeight &&
+          result.startAxleUnit === axleUnit,
+      )!;
+  };
+
+  const expectPermittableResult = (
+    scenario: Scenario,
+    thresholdWeight: number,
+    expectedResult: PolicyCheckResultType,
+  ) => {
+    expect(getPermittableResult(scenario)).toMatchObject({
+      actualWeight: scenario.actualWeight,
+      thresholdWeight,
+      result: expectedResult,
+    });
+  };
+
+  // Source: ASW Permit Weight Maximums.feature @orv2-5709-1.
+  describe('base axle-unit policy maximums', () => {
+    it.each([
+      [1, 1, 9100, undefined, 9100],
+      [2, 1, 11000, undefined, 11000],
+      [2, 2, 23000, undefined, 23000],
+      [3, 3, 28000, 230, 28000],
+    ])(
+      'evaluates axle unit %i with %i axles at %i kg (spread %s, threshold %i kg)',
+      (axleUnit, axleCount, actualWeight, spread, thresholdWeight) => {
+        expectPermittableResult(
+          {
+            axleUnit: axleUnit as 1 | 2 | 3,
+            axleCount: axleCount as number,
+            actualWeight: actualWeight as number,
+            spread: spread as number | undefined,
+          },
+          thresholdWeight as number,
+          PolicyCheckResultType.Pass,
+        );
+      },
+    );
+  });
+
+  // Source: ASW Permit Weight Maximums.feature @orv2-5709-2.
+  describe('single steering axle boundary', () => {
+    it.each([
+      [9100, PolicyCheckResultType.Pass],
+      [9101, PolicyCheckResultType.Fail],
+    ])('evaluates %i kg', (actualWeight, expectedResult) => {
+      expectPermittableResult(
+        { axleUnit: 1, axleCount: 1, actualWeight },
+        9100,
+        expectedResult,
+      );
+    });
+  });
+
+  // Source: ASW Permit Weight Maximums.feature @orv2-5709-3.
+  describe('single non-steering axle boundary', () => {
+    it.each([
+      [11000, PolicyCheckResultType.Pass],
+      [11001, PolicyCheckResultType.Fail],
+    ])('evaluates %i kg', (actualWeight, expectedResult) => {
+      expectPermittableResult(
+        { axleUnit: 2, axleCount: 1, actualWeight },
+        11000,
+        expectedResult,
+      );
+    });
+  });
+
+  // Source: ASW Permit Weight Maximums.feature @orv2-5709-4.
+  describe('tandem axle boundary', () => {
+    it.each([
+      [23000, PolicyCheckResultType.Pass],
+      [23001, PolicyCheckResultType.Fail],
+    ])('evaluates %i kg', (actualWeight, expectedResult) => {
+      expectPermittableResult(
+        { axleUnit: 2, axleCount: 2, actualWeight },
+        23000,
+        expectedResult,
+      );
+    });
+  });
+
+  // Source: ASW Permit Weight Maximums.feature @orv2-5709-5.
+  describe('default tridem axle boundary', () => {
+    it.each([
+      [28000, PolicyCheckResultType.Pass],
+      [28001, PolicyCheckResultType.Fail],
+    ])('evaluates %i kg', (actualWeight, expectedResult) => {
+      expectPermittableResult(
+        {
+          axleUnit: 3,
+          axleCount: 3,
+          spread: 230,
+          actualWeight,
+        },
+        28000,
+        expectedResult,
+      );
+    });
+  });
+
+  // Source: ASW Permit Weight Maximums.feature @orv2-5709-6.
+  describe('tridem spread and immediately following booster', () => {
+    it.each([
+      [240, undefined, 29000, 29000, PolicyCheckResultType.Pass],
+      [370, 1, 29000, 29000, PolicyCheckResultType.Pass],
+      [370, 1, 29001, 29000, PolicyCheckResultType.Fail],
+      [230, undefined, 29000, 28000, PolicyCheckResultType.Fail],
+      [380, undefined, 29000, 28000, PolicyCheckResultType.Fail],
+      [280, 2, 28000, 28000, PolicyCheckResultType.Pass],
+      [280, 2, 29000, 28000, PolicyCheckResultType.Fail],
+      [280, 3, 29000, 28000, PolicyCheckResultType.Fail],
+    ])(
+      'evaluates spread %i cm, booster axles %s, and %i kg',
+      (
+        spread,
+        boosterAxleCount,
+        actualWeight,
+        thresholdWeight,
+        expectedResult,
+      ) => {
+        expectPermittableResult(
+          {
+            axleUnit: 3,
+            axleCount: 3,
+            spread: spread as number,
+            boosterAxleCount: boosterAxleCount as number | undefined,
+            actualWeight: actualWeight as number,
+          },
+          thresholdWeight as number,
+          expectedResult as PolicyCheckResultType,
+        );
+      },
+    );
+  });
+
+  // Source: ASW Permit Weight Maximums.feature @orv2-5709-7.
+  describe('lower applicable checks remain independently binding', () => {
+    it('keeps a 21,000 kg Bridge Formula maximum below a 23,000 kg policy maximum', () => {
+      const axleConfiguration: Array<AxleConfiguration> = [
+        {
+          numberOfAxles: 1,
+          axleUnitWeight: 9000,
+          numberOfTires: 2,
+          tireSize: 455,
+        },
+        {
+          numberOfAxles: 1,
+          interaxleSpacing: 100,
+          axleUnitWeight: 12001,
+          numberOfTires: 4,
+          tireSize: 455,
+        },
+      ];
+      const results = policy.runAxleCalculation(
+        ['TRKTRAC'],
+        axleConfiguration,
+        100000,
+      ).results;
+
+      expect(policy.calculateBridge(axleConfiguration)[0].maxBridge).toBe(
+        21000,
+      );
+      expect(
+        getPermittableResult({
+          axleUnit: 2,
+          axleCount: 2,
+          actualWeight: 23000,
+        }),
+      ).toMatchObject({
+        thresholdWeight: 23000,
+        result: PolicyCheckResultType.Pass,
+      });
+      expect(results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: PolicyCheckId.BridgeFormula,
+            result: PolicyCheckResultType.Fail,
+          }),
+        ]),
+      );
+    });
+
+    it('keeps a 20,500 kg tire-load maximum below a 23,000 kg policy maximum', () => {
+      const axleConfiguration: Array<AxleConfiguration> = [
+        {
+          numberOfAxles: 1,
+          axleUnitWeight: 6000,
+          numberOfTires: 2,
+          tireSize: 455,
+        },
+        {
+          numberOfAxles: 2,
+          axleSpread: 160,
+          interaxleSpacing: 500,
+          axleUnitWeight: 20501,
+          numberOfTires: 8,
+          tireSize: 256.25,
+        },
+      ];
+      const results = policy.runAxleCalculation(
+        ['TRKTRAC'],
+        axleConfiguration,
+        100000,
+      ).results;
+
+      expect(results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: PolicyCheckId.CheckPermittableWeight,
+            startAxleUnit: 2,
+            thresholdWeight: 23000,
+            result: PolicyCheckResultType.Pass,
+          }),
+          expect.objectContaining({
+            id: PolicyCheckId.MaxTireLoad,
+            startAxleUnit: 2,
+            result: PolicyCheckResultType.Fail,
+          }),
+        ]),
+      );
+      expect(8 * 256.25 * 10).toBe(20500);
+    });
+
+    it('keeps a 22,000 kg axle-group maximum below a 23,000 kg policy maximum', () => {
+      const axleConfiguration: Array<AxleConfiguration> = [
+        {
+          numberOfAxles: 1,
+          axleUnitWeight: 6000,
+          numberOfTires: 2,
+          tireSize: 455,
+          vehicleIndex: 0,
+        },
+        {
+          numberOfAxles: 2,
+          axleSpread: 160,
+          interaxleSpacing: 500,
+          axleUnitWeight: 12000,
+          numberOfTires: 8,
+          tireSize: 455,
+          vehicleIndex: 0,
+        },
+        {
+          numberOfAxles: 1,
+          interaxleSpacing: 180,
+          axleUnitWeight: 10001,
+          numberOfTires: 4,
+          tireSize: 455,
+          vehicleIndex: 1,
+        },
+      ];
+      const results = policy.runAxleCalculation(
+        ['TRKTRAC', 'SEMITRL'],
+        axleConfiguration,
+        100000,
+      ).results;
+
+      expect(results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: PolicyCheckId.CheckPermittableWeight,
+            startAxleUnit: 2,
+            thresholdWeight: 23000,
+            result: PolicyCheckResultType.Pass,
+          }),
+          expect.objectContaining({
+            id: PolicyCheckId.AxleGroupMaximumLegalWeightThreshold,
+            startAxleUnit: 2,
+            endAxleUnit: 3,
+            thresholdWeight: 22000,
+            result: PolicyCheckResultType.Fail,
+          }),
+        ]),
+      );
+    });
+  });
+
+  it('lets feature values override conflicting configured permittable values', () => {
+    const conflictingConfig = JSON.parse(
+      JSON.stringify(currentPolicyConfig),
+    ) as PolicyDefinition;
+    const singleSteerTandemDrive =
+      conflictingConfig.globalWeightDefaults!.powerUnits.find(
+        ({ axles }) => axles === 12,
+      )!;
+    singleSteerTandemDrive.saPermittable = 1;
+    singleSteerTandemDrive.daPermittable = 2;
+    const conflictingPolicy = new Policy(conflictingConfig);
+    const results = conflictingPolicy
+      .runAxleCalculation(
+        ['TRKTRAC'],
+        [
+          {
+            numberOfAxles: 1,
+            axleUnitWeight: 9100,
+            numberOfTires: 2,
+            tireSize: 455,
+          },
+          {
+            numberOfAxles: 2,
+            axleSpread: 160,
+            interaxleSpacing: 500,
+            axleUnitWeight: 23000,
+            numberOfTires: 8,
+            tireSize: 455,
+          },
+        ],
+        100000,
+      )
+      .results.filter(({ id }) => id === PolicyCheckId.CheckPermittableWeight);
+
+    expect(results.map(({ thresholdWeight }) => thresholdWeight)).toEqual([
+      9100, 23000,
+    ]);
+  });
+
+  it('preserves configured tandem-steering limits', () => {
+    const configuredPolicyDefinition = JSON.parse(
+      JSON.stringify(currentPolicyConfig),
+    ) as PolicyDefinition;
+    const tandemSteerTandemDrive =
+      configuredPolicyDefinition.globalWeightDefaults!.powerUnits.find(
+        ({ axles }) => axles === 22,
+      )!;
+    tandemSteerTandemDrive.saPermittable = 16555;
+    const configuredPolicy = new Policy(configuredPolicyDefinition);
+    const result = configuredPolicy
+      .runAxleCalculation(
+        ['TRKTRAC'],
+        [
+          {
+            numberOfAxles: 2,
+            axleSpread: 160,
+            axleUnitWeight: 16555,
+            numberOfTires: 4,
+            tireSize: 455,
+          },
+          {
+            numberOfAxles: 2,
+            axleSpread: 160,
+            interaxleSpacing: 500,
+            axleUnitWeight: 17000,
+            numberOfTires: 8,
+            tireSize: 455,
+          },
+        ],
+        100000,
+      )
+      .results.find(
+        ({ id, startAxleUnit }) =>
+          id === PolicyCheckId.CheckPermittableWeight && startAxleUnit === 1,
+      );
+
+    expect(result).toMatchObject({
+      thresholdWeight: 16555,
+      result: PolicyCheckResultType.Pass,
+    });
+  });
+});

--- a/src/_test/unit/pme-policy-config.spec.ts
+++ b/src/_test/unit/pme-policy-config.spec.ts
@@ -8,7 +8,7 @@ import currentPolicyConfig from '../policy-config/_current-config.json';
 describe('PME power-unit policy configuration foundation', () => {
   const policy = new Policy(currentPolicyConfig);
   const pmeTypes = [
-    ['TRUCKPME', 'Truck with PME'],
+    ['TRCKPME', 'Truck with PME'],
     ['TRACPME', 'Truck Tractor with PME'],
   ] as const;
 
@@ -56,7 +56,7 @@ describe('PME power-unit policy configuration foundation', () => {
       );
 
       expect(powerUnits.keys()).toContain('PICKRTT');
-      expect(powerUnits.keys()).toContain('TRUCKPME');
+      expect(powerUnits.keys()).toContain('TRCKPME');
       expect(powerUnits.keys()).toContain('TRACPME');
     },
   );
@@ -84,7 +84,7 @@ describe('PME power-unit policy configuration foundation', () => {
       if (!pickerTruckTractor) {
         expect(
           commodity.powerUnits.some(({ type }) =>
-            ['TRUCKPME', 'TRACPME'].includes(type),
+            ['TRCKPME', 'TRACPME'].includes(type),
           ),
         ).toBe(false);
         continue;
@@ -127,7 +127,7 @@ describe('PME power-unit policy configuration foundation', () => {
       }
 
       expect(permitType.allowedVehicles).toEqual(
-        expect.arrayContaining(['TRUCKPME', 'TRACPME']),
+        expect.arrayContaining(['TRCKPME', 'TRACPME']),
       );
     }
   });

--- a/src/_test/unit/pme-policy-config.spec.ts
+++ b/src/_test/unit/pme-policy-config.spec.ts
@@ -1,0 +1,134 @@
+import { Policy } from '../../policy-engine';
+import currentPolicyConfig from '../policy-config/_current-config.json';
+
+
+// The purpose of this file is to basically add tests for the new PME type, make sure it's there and properly configured.
+// Added on July 2026. 
+
+describe('PME power-unit policy configuration foundation', () => {
+  const policy = new Policy(currentPolicyConfig);
+  const pmeTypes = [
+    ['TRUCKPME', 'Truck with PME'],
+    ['TRACPME', 'Truck Tractor with PME'],
+  ] as const;
+
+  const normalizePowerUnitEligibility = (powerUnit: {
+    type: string;
+    trailers: Array<unknown>;
+  }) => ({
+    ...powerUnit,
+    type: 'NORMALIZED',
+  });
+
+  it.each(pmeTypes)(
+    'defines %s with the expected name and PICKRTT display metadata',
+    (vehicleType, expectedName) => {
+      const pickerTruckTractor = policy.getPowerUnitDefinition('PICKRTT');
+      const pmePowerUnit = policy.getPowerUnitDefinition(vehicleType);
+
+      expect(pmePowerUnit).toEqual({
+        ...pickerTruckTractor,
+        id: vehicleType,
+        name: expectedName,
+      });
+    },
+  );
+
+  it.each(pmeTypes)(
+    'inherits the same configured dimensions as PICKRTT for %s',
+    (vehicleType) => {
+      for (const axleConfiguration of [11, 12, 13, 22, 23]) {
+        expect(
+          policy.getDefaultPowerUnitWeight(vehicleType, axleConfiguration),
+        ).toEqual(
+          policy.getDefaultPowerUnitWeight('PICKRTT', axleConfiguration),
+        );
+      }
+    },
+  );
+
+  it.each(['XXXXXXX', 'EMPTYXX', 'NONREDU'])(
+    'makes both PME types selectable wherever PICKRTT is selectable for STOW %s',
+    (commodityType) => {
+      const powerUnits = policy.getPermittablePowerUnitTypes(
+        'STOW',
+        commodityType,
+      );
+
+      expect(powerUnits.keys()).toContain('PICKRTT');
+      expect(powerUnits.keys()).toContain('TRUCKPME');
+      expect(powerUnits.keys()).toContain('TRACPME');
+    },
+  );
+
+  it.each(pmeTypes)(
+    'accepts STOW / NONREDU / %s with a semi-trailer',
+    (vehicleType) => {
+      expect(
+        policy.isConfigurationValid(
+          'STOW',
+          'NONREDU',
+          [vehicleType, 'SEMITRL'],
+          false,
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it('clones normalized PICKRTT commodity and trailer eligibility for both PME types', () => {
+    for (const commodity of currentPolicyConfig.commodities) {
+      const pickerTruckTractor = commodity.powerUnits.find(
+        (powerUnit) => powerUnit.type === 'PICKRTT',
+      );
+
+      if (!pickerTruckTractor) {
+        expect(
+          commodity.powerUnits.some(({ type }) =>
+            ['TRUCKPME', 'TRACPME'].includes(type),
+          ),
+        ).toBe(false);
+        continue;
+      }
+
+      for (const [vehicleType] of pmeTypes) {
+        const pmePowerUnit = commodity.powerUnits.find(
+          (powerUnit) => powerUnit.type === vehicleType,
+        );
+        expect(normalizePowerUnitEligibility(pmePowerUnit!)).toEqual(
+          normalizePowerUnitEligibility(pickerTruckTractor),
+        );
+      }
+    }
+  });
+
+  it('clones PICKRTT permit allowed-vehicle eligibility without changing PICKRTT', () => {
+    const pickerDefinition = policy.getPowerUnitDefinition('PICKRTT');
+
+    expect(pickerDefinition).toMatchObject({
+      id: 'PICKRTT',
+      name: 'Picker Truck Tractors',
+      category: 'powerunit',
+      displayCodePrefix: 'TT',
+      displayCodeSteerAxle: 'S',
+      displayCodeDriveAxle: 'D',
+    });
+    expect(
+      policy.isConfigurationValid(
+        'STOW',
+        'NONREDU',
+        ['PICKRTT', 'SEMITRL'],
+        false,
+      ),
+    ).toBe(true);
+
+    for (const permitType of currentPolicyConfig.permitTypes) {
+      if (!permitType.allowedVehicles?.includes('PICKRTT')) {
+        continue;
+      }
+
+      expect(permitType.allowedVehicles).toEqual(
+        expect.arrayContaining(['TRUCKPME', 'TRACPME']),
+      );
+    }
+  });
+});

--- a/src/_test/unit/run-axle-calculation-regressions.spec.ts
+++ b/src/_test/unit/run-axle-calculation-regressions.spec.ts
@@ -1,0 +1,107 @@
+import { Policy } from '../../policy-engine';
+import { PolicyCheckId, PolicyCheckResultType } from '../../enum';
+import {
+  AxleCalcResults,
+  AxleConfiguration,
+  AxleGroupPolicyCheckResult,
+} from '../../types';
+import currentPolicyConfig from '../policy-config/_current-config.json';
+
+describe('runAxleCalculation robustness regressions', () => {
+  const policy = new Policy(currentPolicyConfig);
+
+  const validFirstAxle: AxleConfiguration = {
+    numberOfAxles: 1,
+    axleUnitWeight: 5000,
+    numberOfTires: 2,
+    tireSize: 279,
+    vehicleIndex: 0,
+  };
+
+  const validSecondAxle: AxleConfiguration = {
+    ...validFirstAxle,
+    interaxleSpacing: 300,
+  };
+
+  const expectBridgeInputFailure = (
+    axleConfiguration: AxleConfiguration[],
+    expectedMessage: string,
+    expectedAxleUnit: number,
+  ) => {
+    let calculation: AxleCalcResults | undefined;
+
+    expect(() => {
+      calculation = policy.runAxleCalculation(
+        ['CRANEAT'],
+        axleConfiguration,
+        100000,
+      );
+    }).not.toThrow();
+
+    expect(calculation!.results).toContainEqual(
+      expect.objectContaining<Partial<AxleGroupPolicyCheckResult>>({
+        id: PolicyCheckId.BridgeFormula,
+        result: PolicyCheckResultType.Fail,
+        message: expectedMessage,
+        startAxleUnit: expectedAxleUnit,
+        endAxleUnit: expectedAxleUnit,
+      }),
+    );
+  };
+
+  it('returns a failed result for invalid interaxle spacing instead of throwing', () => {
+    expectBridgeInputFailure(
+      [{ ...validFirstAxle }, { ...validSecondAxle, interaxleSpacing: -1000 }],
+      'Axle spacing before axle unit 2 must be a finite number greater than 0.',
+      2,
+    );
+  });
+
+  it('returns a failed result for invalid first-unit axle spread instead of throwing', () => {
+    expectBridgeInputFailure(
+      [
+        {
+          ...validFirstAxle,
+          numberOfAxles: 2,
+          numberOfTires: 4,
+          axleSpread: -1000,
+        },
+        { ...validSecondAxle },
+      ],
+      'Axle spread for axle unit 1 must be a finite number greater than 0 when the unit has multiple axles.',
+      1,
+    );
+  });
+
+  it('returns a failed result for invalid later-unit axle spread instead of throwing', () => {
+    expectBridgeInputFailure(
+      [
+        { ...validFirstAxle },
+        {
+          ...validSecondAxle,
+          numberOfAxles: 2,
+          numberOfTires: 4,
+          axleSpread: -1000,
+        },
+      ],
+      'Axle spread for axle unit 2 must be a finite number greater than 0 when the unit has multiple axles.',
+      2,
+    );
+  });
+
+  it('returns a failed result for invalid first-unit weight instead of throwing', () => {
+    expectBridgeInputFailure(
+      [{ ...validFirstAxle, axleUnitWeight: -100000 }, { ...validSecondAxle }],
+      'Axle unit weight for axle unit 1 must be a finite number greater than 0.',
+      1,
+    );
+  });
+
+  it('returns a failed result for invalid later-unit weight instead of throwing', () => {
+    expectBridgeInputFailure(
+      [{ ...validFirstAxle }, { ...validSecondAxle, axleUnitWeight: -100000 }],
+      'Axle unit weight for axle unit 2 must be a finite number greater than 0.',
+      2,
+    );
+  });
+});

--- a/src/_test/unit/stow-validation.spec.ts
+++ b/src/_test/unit/stow-validation.spec.ts
@@ -145,6 +145,7 @@ describe('Single Trip Overweight Policy Configuration Validator', () => {
     permit.permitData.startDate = dayjs().format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
+    permit.permitData.vehicleConfiguration.axleConfiguration[0].axleUnitWeight = 6000;
     return permit;
   };
 
@@ -243,6 +244,69 @@ describe('Single Trip Overweight Policy Configuration Validator', () => {
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.violations).toHaveLength(1);
+  });
+
+  // Source: ASW Legal Weight Maximums.feature @orv2-5706.
+  it('exposes an above-legal axle-unit failure through validate', async () => {
+    const permit = getDatedPermit();
+    permit.permitData.vehicleConfiguration.axleConfiguration[0].axleUnitWeight = 6001;
+
+    const validationResult = await policy.validate(permit);
+    const legalFailure = validationResult.axleCalculationResults?.results.find(
+      ({ id, startAxleUnit }) =>
+        id === PolicyCheckId.CheckLegalWeight && startAxleUnit === 1,
+    );
+
+    expect(legalFailure).toMatchObject({
+      result: PolicyCheckResultType.Fail,
+      actualWeight: 6001,
+      thresholdWeight: 6000,
+    });
+    expect(validationResult.violations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message:
+            'Vehicle configuration failed axle calculation policy checks',
+          details: expect.arrayContaining([
+            'Weight for axle unit 1 must not exceed 6000 kgs',
+          ]),
+        }),
+      ]),
+    );
+  });
+
+  // Source: ASW Permit Weight Maximums.feature @orv2-5709.
+  it('exposes an above-permittable axle-unit failure through validate', async () => {
+    const permit = getDatedPermit();
+    const driveAxle =
+      permit.permitData.vehicleConfiguration.axleConfiguration[1];
+    driveAxle.axleUnitWeight = 23001;
+    driveAxle.numberOfTires = 8;
+    driveAxle.tireSize = 455;
+
+    const validationResult = await policy.validate(permit);
+    const permittableFailure =
+      validationResult.axleCalculationResults?.results.find(
+        ({ id, startAxleUnit }) =>
+          id === PolicyCheckId.CheckPermittableWeight && startAxleUnit === 2,
+      );
+
+    expect(permittableFailure).toMatchObject({
+      result: PolicyCheckResultType.Fail,
+      actualWeight: 23001,
+      thresholdWeight: 23000,
+    });
+    expect(validationResult.violations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message:
+            'Vehicle configuration failed axle calculation policy checks',
+          details: expect.arrayContaining([
+            'Weight for axle unit 2 must not exceed 23000 kgs',
+          ]),
+        }),
+      ]),
+    );
   });
 
   it('should raise STOW axle calculation violation when an axle unit has zero axles', async () => {

--- a/src/enum/policy-check.ts
+++ b/src/enum/policy-check.ts
@@ -8,6 +8,7 @@ export enum PolicyCheckId {
   AxleGroupMaximumLegalWeightThreshold = 'axle-group-maximum-legal-weight-threshold',
   BoosterAxleLimit = 'booster-axle-limit',
   BridgeFormula = 'bridge-formula',
+  CheckLegalWeight = 'check-legal-weight',
   CheckPermittableWeight = 'check-permittable-weight',
   DriveJeepLoadEqualization = 'drive-jeep-load-equalization',
   MaxTireLoad = 'max-tire-load',

--- a/src/helper/policy-check.helper.ts
+++ b/src/helper/policy-check.helper.ts
@@ -3,8 +3,6 @@ import {
   AxleConfiguration,
   AxleUnitPolicyCheckResult,
   AxleGroupPolicyCheckResult,
-  WeightDimension,
-  SingleAxleDimension,
 } from 'onroute-policy-engine/types';
 import { Policy } from 'onroute-policy-engine';
 import { getAxleUnitVehicleIndexes } from './dimensions.helper';
@@ -82,6 +80,162 @@ function getApplicableLegalWeightThreshold(
     axleConfiguration,
     axleIndex,
   )?.legal;
+}
+
+function getAxleUnitVehicleIndexLookup(
+  policy: Policy,
+  vehicleConfiguration: Array<string>,
+  axleConfiguration: Array<AxleConfiguration>,
+): Array<number> {
+  return axleConfiguration.some(
+    (axleUnit) => axleUnit.vehicleIndex !== undefined,
+  )
+    ? getAxleUnitVehicleIndexes(policy, vehicleConfiguration, axleConfiguration)
+    : axleConfiguration.map((_, axleIndex) =>
+        axleIndex < 2 ? 0 : axleIndex - 1,
+      );
+}
+
+function getConfiguredAxleUnitWeightThreshold(
+  policy: Policy,
+  vehicleConfiguration: Array<string>,
+  axleConfiguration: Array<AxleConfiguration>,
+  axleUnitVehicleIndexes: Array<number>,
+  axleIndex: number,
+  threshold: 'legal' | 'permittable',
+): number {
+  const vehicleIndex = axleUnitVehicleIndexes[axleIndex];
+  const vehicleType = vehicleConfiguration[vehicleIndex];
+  const axleUnit = axleConfiguration[axleIndex];
+
+  if (!vehicleType || !axleUnit) {
+    return 0;
+  }
+
+  const weights =
+    vehicleIndex === 0
+      ? policy.getDefaultPowerUnitWeight(
+          vehicleType,
+          axleConfiguration[0].numberOfAxles * 10 +
+            axleConfiguration[1].numberOfAxles,
+        )
+      : policy.getDefaultTrailerWeight(vehicleType, axleUnit.numberOfAxles);
+
+  if (weights.length === 0) {
+    return 0;
+  }
+
+  return (
+    policy.selectCorrectWeightDimension(
+      weights,
+      vehicleConfiguration,
+      axleConfiguration,
+      axleIndex,
+    )?.[threshold] ?? 0
+  );
+}
+
+function isFeatureLegalWeightPowerUnit(vehicleType?: string): boolean {
+  return (
+    vehicleType === 'REGTRCK' ||
+    vehicleType === 'TRKTRAC' ||
+    vehicleType === 'TRUCKPME' ||
+    vehicleType === 'TRACPME'
+  );
+}
+
+function getFeatureLegalPowerUnitWeightThreshold(
+  vehicleType: string,
+  axleConfiguration: Array<AxleConfiguration>,
+  axleIndex: number,
+): number | undefined {
+  const steerAxle = axleConfiguration[0];
+  const driveAxle = axleConfiguration[1];
+  const hasPme = vehicleType === 'TRUCKPME' || vehicleType === 'TRACPME';
+
+  if (axleIndex === 0) {
+    if (
+      steerAxle.numberOfAxles === 1 &&
+      (driveAxle.numberOfAxles === 1 || driveAxle.numberOfAxles === 2)
+    ) {
+      return hasPme || vehicleType === 'REGTRCK' ? 9100 : 6000;
+    }
+    if (steerAxle.numberOfAxles === 1 && driveAxle.numberOfAxles === 3) {
+      return hasPme ? 9100 : 7300;
+    }
+    if (steerAxle.numberOfAxles === 2 && driveAxle.numberOfAxles === 2) {
+      return 17000;
+    }
+    if (steerAxle.numberOfAxles === 2 && driveAxle.numberOfAxles === 3) {
+      return hasPme ? 15200 : 13600;
+    }
+  }
+
+  if (axleIndex === 1) {
+    return {
+      1: 9100,
+      2: 17000,
+      3: 24000,
+    }[driveAxle.numberOfAxles];
+  }
+
+  return undefined;
+}
+
+/**
+ * Validates each axle unit against its legal weight maximum.
+ *
+ * The feature-defined steering and drive limits are authoritative for the
+ * standard truck/truck-tractor and PME subtypes. Other axle units retain
+ * their configured legal weight lookup.
+ */
+export function CheckLegalWeight(
+  policy: Policy,
+  vehicleConfiguration: Array<string>,
+  axleConfiguration: Array<AxleConfiguration>,
+): Array<PolicyCheckResult> {
+  const policyId = PolicyCheckId.CheckLegalWeight;
+  const powerUnitType = vehicleConfiguration[0];
+  const axleUnitVehicleIndexes = getAxleUnitVehicleIndexLookup(
+    policy,
+    vehicleConfiguration,
+    axleConfiguration,
+  );
+
+  return axleConfiguration.map((axleUnit, axleIndex) => {
+    const featureThreshold =
+      axleUnitVehicleIndexes[axleIndex] === 0 &&
+      isFeatureLegalWeightPowerUnit(powerUnitType)
+        ? getFeatureLegalPowerUnitWeightThreshold(
+            powerUnitType,
+            axleConfiguration,
+            axleIndex,
+          )
+        : undefined;
+    const legalWeight =
+      featureThreshold ??
+      getConfiguredAxleUnitWeightThreshold(
+        policy,
+        vehicleConfiguration,
+        axleConfiguration,
+        axleUnitVehicleIndexes,
+        axleIndex,
+        'legal',
+      );
+    const result = axleUnit.axleUnitWeight <= legalWeight;
+    const axleUnitNumber = axleIndex + 1;
+
+    return {
+      id: policyId,
+      message: `Weight for axle unit ${axleUnitNumber} ${
+        result ? 'is legal' : `must not exceed ${legalWeight} kgs`
+      }`,
+      result: result ? PolicyCheckResultType.Pass : PolicyCheckResultType.Fail,
+      axleUnit: axleUnitNumber,
+      actualWeight: axleUnit.axleUnitWeight,
+      thresholdWeight: legalWeight,
+    } as AxleUnitPolicyCheckResult;
+  });
 }
 
 /**
@@ -460,122 +614,71 @@ export function CheckPermittableWeight(
   vehicleConfiguration: Array<string>,
   axleConfiguration: Array<AxleConfiguration>,
 ): Array<PolicyCheckResult> {
-  const policyCheckResults = new Array<AxleUnitPolicyCheckResult>();
   const policyId = PolicyCheckId.CheckPermittableWeight;
-  const hasVehicleIndexes = axleConfiguration.some(
-    (axleUnit) => axleUnit.vehicleIndex !== undefined,
-  );
-
-  // Legacy John Fletcher implementation, restored from:
-  // git show e4a9d6badd025dec844df43379f776a4995ad75b^:src/helper/policy-check.helper.ts
-  if (!hasVehicleIndexes) {
-    const singleAxleDimensions: Array<SingleAxleDimension> = [];
-
-    vehicleConfiguration.forEach((vc, i) => {
-      let weight: Array<WeightDimension>;
-      if (i === 0) {
-        const powerUnitAxles =
-          axleConfiguration[0].numberOfAxles * 10 +
-          axleConfiguration[1].numberOfAxles;
-
-        weight = policy.getDefaultPowerUnitWeight(vc, powerUnitAxles);
-        const steerAxleDimension =
-          policy.selectCorrectWeightDimension(
-            weight,
-            vehicleConfiguration,
-            axleConfiguration,
-            0,
-          ) || {};
-        singleAxleDimensions.push(steerAxleDimension);
-        const driveAxleDimension =
-          policy.selectCorrectWeightDimension(
-            weight,
-            vehicleConfiguration,
-            axleConfiguration,
-            1,
-          ) || {};
-        singleAxleDimensions.push(driveAxleDimension);
-      } else if (i + 1 < axleConfiguration.length) {
-        weight = policy.getDefaultTrailerWeight(
-          vc,
-          axleConfiguration[i + 1].numberOfAxles,
-        );
-        const trailerDimension =
-          policy.selectCorrectWeightDimension(
-            weight,
-            vehicleConfiguration,
-            axleConfiguration,
-            i + 1,
-          ) || {};
-        singleAxleDimensions.push(trailerDimension);
-      }
-    });
-
-    axleConfiguration.forEach((ac, i) => {
-      const actualWeight = ac.axleUnitWeight;
-      const permittableWeight = singleAxleDimensions[i].permittable || 0;
-      const result = actualWeight <= permittableWeight;
-      const axleUnit = i + 1;
-      const message = `Weight for axle unit ${axleUnit} ${result ? 'is permittable' : `must not exceed ${permittableWeight} kgs`}`;
-      policyCheckResults.push({
-        id: policyId,
-        message: message,
-        result: result
-          ? PolicyCheckResultType.Pass
-          : PolicyCheckResultType.Fail,
-        axleUnit: axleUnit,
-        actualWeight: actualWeight,
-        thresholdWeight: permittableWeight,
-      });
-    });
-
-    return policyCheckResults;
-  }
-
-  // Explicit multi-axle ownership path supplied by the consuming application.
-  // This is the new way, using { vehicleIndex: num }
-  const axleUnitVehicleIndexes = getAxleUnitVehicleIndexes(
+  const axleUnitVehicleIndexes = getAxleUnitVehicleIndexLookup(
     policy,
     vehicleConfiguration,
     axleConfiguration,
   );
 
-  axleConfiguration.forEach((ac, i) => {
-    const vehicleIndex = axleUnitVehicleIndexes[i];
-    const vehicleType = vehicleConfiguration[vehicleIndex];
-    const weight =
-      vehicleIndex === 0
-        ? policy.getDefaultPowerUnitWeight(
-            vehicleType,
-            axleConfiguration[0].numberOfAxles * 10 +
-              axleConfiguration[1].numberOfAxles,
-          )
-        : policy.getDefaultTrailerWeight(vehicleType, ac.numberOfAxles);
-    const axleDimension =
-      weight.length > 0
-        ? policy.selectCorrectWeightDimension(
-            weight,
-            vehicleConfiguration,
-            axleConfiguration,
-            i,
-          ) || {}
-        : {};
-    const actualWeight = ac.axleUnitWeight;
-    const permittableWeight = axleDimension.permittable || 0;
-    const result = actualWeight <= permittableWeight;
-    const axleUnit = i + 1;
-    const message = `Weight for axle unit ${axleUnit} ${result ? 'is permittable' : `must not exceed ${permittableWeight} kgs`}`;
-    policyCheckResults.push({
-      id: policyId,
-      message: message,
-      result: result ? PolicyCheckResultType.Pass : PolicyCheckResultType.Fail,
-      axleUnit: axleUnit,
-      actualWeight: actualWeight,
-      thresholdWeight: permittableWeight,
-    });
-  });
+  return axleConfiguration.map((axleUnit, axleIndex) => {
+    const vehicleIndex = axleUnitVehicleIndexes[axleIndex];
+    const isSingleSteer =
+      axleIndex === 0 && vehicleIndex === 0 && axleUnit.numberOfAxles === 1;
+    const isTandemSteer =
+      axleIndex === 0 && vehicleIndex === 0 && axleUnit.numberOfAxles === 2;
+    let permittableWeight: number | undefined;
 
-  return policyCheckResults;
+    if (isSingleSteer) {
+      permittableWeight = 9100;
+    } else if (!isTandemSteer) {
+      if (axleUnit.numberOfAxles === 1) {
+        permittableWeight = 11000;
+      } else if (axleUnit.numberOfAxles === 2) {
+        permittableWeight = 23000;
+      } else if (axleUnit.numberOfAxles === 3) {
+        const spreadQualifies =
+          axleUnit.axleSpread !== undefined &&
+          axleUnit.axleSpread >= 240 &&
+          axleUnit.axleSpread <= 370;
+        const nextVehicleIndex = vehicleIndex + 1;
+        const hasImmediatelyFollowingBooster =
+          vehicleConfiguration[nextVehicleIndex] ===
+          AccessoryVehicleType.Booster;
+        const boosterAxle = axleConfiguration.find(
+          (_, candidateIndex) =>
+            candidateIndex > axleIndex &&
+            axleUnitVehicleIndexes[candidateIndex] === nextVehicleIndex,
+        );
+        const boosterQualifies =
+          !hasImmediatelyFollowingBooster || boosterAxle?.numberOfAxles === 1;
+
+        permittableWeight = spreadQualifies && boosterQualifies ? 29000 : 28000;
+      }
+    }
+
+    permittableWeight ??= getConfiguredAxleUnitWeightThreshold(
+      policy,
+      vehicleConfiguration,
+      axleConfiguration,
+      axleUnitVehicleIndexes,
+      axleIndex,
+      'permittable',
+    );
+
+    const result = axleUnit.axleUnitWeight <= permittableWeight;
+    const axleUnitNumber = axleIndex + 1;
+    return {
+      id: policyId,
+      message: `Weight for axle unit ${axleUnitNumber} ${
+        result ? 'is permittable' : `must not exceed ${permittableWeight} kgs`
+      }`,
+      result: result ? PolicyCheckResultType.Pass : PolicyCheckResultType.Fail,
+      axleUnit: axleUnitNumber,
+      actualWeight: axleUnit.axleUnitWeight,
+      thresholdWeight: permittableWeight,
+    } as AxleUnitPolicyCheckResult;
+  });
 }
 
 /**
@@ -1499,6 +1602,7 @@ export function CheckDriveJeepLoadEqualization(
  * Currently includes:
  * - AxleGroupMaximumLegalWeightThreshold: Validates axle groups within 8 m against CTR 7.17
  * - BridgeFormula: Validates axle groups against bridge formula requirements
+ * - CheckLegalWeight: Validates axle units against legal weight limits
  * - CheckPermittableWeight: Validates total vehicle weight against permit limits
  * - MaxTireLoad: Validates tire load capacity for each axle unit
  * - MinDriveAxleWeight: Validates minimum weight requirements for drive axles
@@ -1523,6 +1627,7 @@ export const policyCheckMap = new Map<string, PolicyCheck>([
     PolicyCheckId.AxleGroupMaximumLegalWeightThreshold,
     CheckAxleGroupMaximumLegalWeightThreshold,
   ],
+  [PolicyCheckId.CheckLegalWeight, CheckLegalWeight],
   [PolicyCheckId.CheckPermittableWeight, CheckPermittableWeight],
   [PolicyCheckId.MaxTireLoad, CheckMaxTireLoad],
   [PolicyCheckId.MinDriveAxleWeight, CheckMinDriveAxleWeight],

--- a/src/helper/policy-check.helper.ts
+++ b/src/helper/policy-check.helper.ts
@@ -33,6 +33,31 @@ type PolicyCheck = (
   axleConfiguration: Array<AxleConfiguration>,
 ) => Array<PolicyCheckResult>;
 
+const POWER_UNIT_AXLE_CODE_MULTIPLIER = 10;
+
+const LEGAL_WEIGHT_MAXIMUM_KG = {
+  SINGLE_AXLE: 9100,
+  STANDARD_TRUCK_TRACTOR_STEER: 6000,
+  STANDARD_SINGLE_STEER_WITH_TRIDEM_DRIVE: 7300,
+  TANDEM_AXLE: 17000,
+  STANDARD_TANDEM_STEER_WITH_TRIDEM_DRIVE: 13600,
+  PME_TANDEM_STEER_WITH_TRIDEM_DRIVE: 15200,
+  TRIDEM_AXLE: 24000,
+} as const;
+
+const PERMITTABLE_WEIGHT_MAXIMUM_KG = {
+  SINGLE_STEER: 9100,
+  SINGLE_NON_STEER: 11000,
+  TANDEM: 23000,
+  STANDARD_TRIDEM: 28000,
+  QUALIFYING_TRIDEM: 29000,
+} as const;
+
+const QUALIFYING_TRIDEM_SPREAD_CM = {
+  MINIMUM: 240,
+  MAXIMUM: 370,
+} as const;
+
 /** Applies the standard lower-of rule or the exact 7.16(g) exception. */
 export function getMaximumLegalAxleGroupWeightThreshold(
   individualLegalWeightSum: number,
@@ -65,7 +90,7 @@ function getApplicableLegalWeightThreshold(
     vehicleIndex === 0
       ? policy.getDefaultPowerUnitWeight(
           vehicleType,
-          axleConfiguration[0].numberOfAxles * 10 +
+          axleConfiguration[0].numberOfAxles * POWER_UNIT_AXLE_CODE_MULTIPLIER +
             axleConfiguration[1].numberOfAxles,
         )
       : policy.getDefaultTrailerWeight(vehicleType, axle.numberOfAxles);
@@ -116,7 +141,7 @@ function getConfiguredAxleUnitWeightThreshold(
     vehicleIndex === 0
       ? policy.getDefaultPowerUnitWeight(
           vehicleType,
-          axleConfiguration[0].numberOfAxles * 10 +
+          axleConfiguration[0].numberOfAxles * POWER_UNIT_AXLE_CODE_MULTIPLIER +
             axleConfiguration[1].numberOfAxles,
         )
       : policy.getDefaultTrailerWeight(vehicleType, axleUnit.numberOfAxles);
@@ -139,7 +164,7 @@ function isFeatureLegalWeightPowerUnit(vehicleType?: string): boolean {
   return (
     vehicleType === 'REGTRCK' ||
     vehicleType === 'TRKTRAC' ||
-    vehicleType === 'TRUCKPME' ||
+    vehicleType === 'TRCKPME' ||
     vehicleType === 'TRACPME'
   );
 }
@@ -151,31 +176,37 @@ function getFeatureLegalPowerUnitWeightThreshold(
 ): number | undefined {
   const steerAxle = axleConfiguration[0];
   const driveAxle = axleConfiguration[1];
-  const hasPme = vehicleType === 'TRUCKPME' || vehicleType === 'TRACPME';
+  const hasPme = vehicleType === 'TRCKPME' || vehicleType === 'TRACPME';
 
   if (axleIndex === 0) {
     if (
       steerAxle.numberOfAxles === 1 &&
       (driveAxle.numberOfAxles === 1 || driveAxle.numberOfAxles === 2)
     ) {
-      return hasPme || vehicleType === 'REGTRCK' ? 9100 : 6000;
+      return hasPme || vehicleType === 'REGTRCK'
+        ? LEGAL_WEIGHT_MAXIMUM_KG.SINGLE_AXLE
+        : LEGAL_WEIGHT_MAXIMUM_KG.STANDARD_TRUCK_TRACTOR_STEER;
     }
     if (steerAxle.numberOfAxles === 1 && driveAxle.numberOfAxles === 3) {
-      return hasPme ? 9100 : 7300;
+      return hasPme
+        ? LEGAL_WEIGHT_MAXIMUM_KG.SINGLE_AXLE
+        : LEGAL_WEIGHT_MAXIMUM_KG.STANDARD_SINGLE_STEER_WITH_TRIDEM_DRIVE;
     }
     if (steerAxle.numberOfAxles === 2 && driveAxle.numberOfAxles === 2) {
-      return 17000;
+      return LEGAL_WEIGHT_MAXIMUM_KG.TANDEM_AXLE;
     }
     if (steerAxle.numberOfAxles === 2 && driveAxle.numberOfAxles === 3) {
-      return hasPme ? 15200 : 13600;
+      return hasPme
+        ? LEGAL_WEIGHT_MAXIMUM_KG.PME_TANDEM_STEER_WITH_TRIDEM_DRIVE
+        : LEGAL_WEIGHT_MAXIMUM_KG.STANDARD_TANDEM_STEER_WITH_TRIDEM_DRIVE;
     }
   }
 
   if (axleIndex === 1) {
     return {
-      1: 9100,
-      2: 17000,
-      3: 24000,
+      1: LEGAL_WEIGHT_MAXIMUM_KG.SINGLE_AXLE,
+      2: LEGAL_WEIGHT_MAXIMUM_KG.TANDEM_AXLE,
+      3: LEGAL_WEIGHT_MAXIMUM_KG.TRIDEM_AXLE,
     }[driveAxle.numberOfAxles];
   }
 
@@ -435,6 +466,47 @@ export function CheckNumberOfAxles(
   return policyCheckResults;
 }
 
+function getBridgeFormulaInputFailure(
+  axleConfiguration: Array<AxleConfiguration>,
+): AxleGroupPolicyCheckResult | undefined {
+  for (let axleIndex = 0; axleIndex < axleConfiguration.length; axleIndex++) {
+    const axleUnit = axleConfiguration[axleIndex];
+    const axleUnitNumber = axleIndex + 1;
+    let message: string | undefined;
+
+    if (
+      !Number.isFinite(axleUnit.axleUnitWeight) ||
+      axleUnit.axleUnitWeight <= 0
+    ) {
+      message = `Axle unit weight for axle unit ${axleUnitNumber} must be a finite number greater than 0.`;
+    } else if (
+      axleUnit.numberOfAxles > 1 &&
+      (!Number.isFinite(axleUnit.axleSpread) ||
+        (axleUnit.axleSpread as number) <= 0)
+    ) {
+      message = `Axle spread for axle unit ${axleUnitNumber} must be a finite number greater than 0 when the unit has multiple axles.`;
+    } else if (
+      axleIndex > 0 &&
+      (!Number.isFinite(axleUnit.interaxleSpacing) ||
+        (axleUnit.interaxleSpacing as number) <= 0)
+    ) {
+      message = `Axle spacing before axle unit ${axleUnitNumber} must be a finite number greater than 0.`;
+    }
+
+    if (message) {
+      return {
+        id: PolicyCheckId.BridgeFormula,
+        message,
+        result: PolicyCheckResultType.Fail,
+        startAxleUnit: axleUnitNumber,
+        endAxleUnit: axleUnitNumber,
+      };
+    }
+  }
+
+  return undefined;
+}
+
 /**
  * Performs bridge formula calculations on axle groups and returns policy check results.
  *
@@ -468,6 +540,12 @@ export function CheckBridgeFormula(
 ): Array<PolicyCheckResult> {
   const policyCheckResults = new Array<AxleGroupPolicyCheckResult>();
   const policyId = PolicyCheckId.BridgeFormula;
+  const inputFailure = getBridgeFormulaInputFailure(axleConfiguration);
+
+  if (inputFailure) {
+    return [inputFailure];
+  }
+
   const bridgeCalcResults = policy.calculateBridge(axleConfiguration);
   bridgeCalcResults.forEach((br) => {
     const message = `Axle group ${br.startAxleUnit} to ${br.endAxleUnit} ${br.success ? 'passes' : 'does not pass'} bridge formula.`;
@@ -630,17 +708,17 @@ export function CheckPermittableWeight(
     let permittableWeight: number | undefined;
 
     if (isSingleSteer) {
-      permittableWeight = 9100;
+      permittableWeight = PERMITTABLE_WEIGHT_MAXIMUM_KG.SINGLE_STEER;
     } else if (!isTandemSteer) {
       if (axleUnit.numberOfAxles === 1) {
-        permittableWeight = 11000;
+        permittableWeight = PERMITTABLE_WEIGHT_MAXIMUM_KG.SINGLE_NON_STEER;
       } else if (axleUnit.numberOfAxles === 2) {
-        permittableWeight = 23000;
+        permittableWeight = PERMITTABLE_WEIGHT_MAXIMUM_KG.TANDEM;
       } else if (axleUnit.numberOfAxles === 3) {
         const spreadQualifies =
           axleUnit.axleSpread !== undefined &&
-          axleUnit.axleSpread >= 240 &&
-          axleUnit.axleSpread <= 370;
+          axleUnit.axleSpread >= QUALIFYING_TRIDEM_SPREAD_CM.MINIMUM &&
+          axleUnit.axleSpread <= QUALIFYING_TRIDEM_SPREAD_CM.MAXIMUM;
         const nextVehicleIndex = vehicleIndex + 1;
         const hasImmediatelyFollowingBooster =
           vehicleConfiguration[nextVehicleIndex] ===
@@ -653,7 +731,10 @@ export function CheckPermittableWeight(
         const boosterQualifies =
           !hasImmediatelyFollowingBooster || boosterAxle?.numberOfAxles === 1;
 
-        permittableWeight = spreadQualifies && boosterQualifies ? 29000 : 28000;
+        permittableWeight =
+          spreadQualifies && boosterQualifies
+            ? PERMITTABLE_WEIGHT_MAXIMUM_KG.QUALIFYING_TRIDEM
+            : PERMITTABLE_WEIGHT_MAXIMUM_KG.STANDARD_TRIDEM;
       }
     }
 


### PR DESCRIPTION
This PR is about adding two new (identical) vehicle types: Truck with PME and Truck Tractor with PME.  These two new PME types should basically be exact clones of "Picker Truck Tractor" at a functional/vehicle configuration level. Everywhere Picker Truck Tractor is allowed these two new PME options should also be allowed (across the entire application, not just STOW).

When adding a new vehicle, it's not just the changes in this PR of adding to JSON and DDL files - it ALSO requires adding it to backend dbs. We need a bit more investigation into that, and need to figure out scheduling / how to plan the actual rollout here.

Example DB work to at least start investigation:

```
--master tables
select * from ORBC_POWER_UNIT_TYPE;
select * from ORBC_TRAILER_TYPE;

--configure for the permit
select * from ORBC_POLICY_CONFIGURATION
```