### PR TITLE
feat: Add STWSE related config and logic to policy engine

### DIFF
--- a/src/_examples/usage/node-backend-example/src/config/_current-config.json
+++ b/src/_examples/usage/node-backend-example/src/config/_current-config.json
@@ -1971,6 +1971,274 @@
       "conditions": []
     },
     {
+      "id": "STWSE",
+      "name": "Single Trip GVW Increase",
+      "routingRequired": true,
+      "weightDimensionRequired": true,
+      "sizeDimensionRequired": true,
+      "commodityRequired": false,
+      "allowedVehicles": [
+        "CONCRET",
+        "CRANEAT",
+        "CRANEMB",
+        "GRADERS",
+        "LWBTRCT",
+        "MUNFITR",
+        "OGBEDTK",
+        "OGOILSW",
+        "OGSERVC",
+        "OGSRRAH",
+        "PICKRTT",
+        "PICKRTR",
+        "RBTRLDR",
+        "TLSCONV",
+        "TOWVEHC",
+        "TRKTRAC",
+        "REGTRCK",
+        "TRCKPME",
+        "TRACPME"
+      ],
+      "rules": [
+        {
+          "conditions": {
+            "any": [
+              {
+                "not": {
+                  "fact": "permitData",
+                  "path": "permitDuration",
+                  "operator": "lessThanInclusive",
+                  "value": 7
+                }
+              },
+              {
+                "not": {
+                  "fact": "permitData",
+                  "path": "permitDuration",
+                  "operator": "greaterThan",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Duration must be 7 days or less",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.permitDuration"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "vehicleConfiguration.overallWidth",
+              "operator": "greaterThan",
+              "value": 0
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Must be greater than 0m.",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.vehicleConfiguration.overallWidth"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "vehicleConfiguration.overallHeight",
+              "operator": "greaterThan",
+              "value": 0
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Must be greater than 0m.",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.vehicleConfiguration.overallHeight"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "vehicleConfiguration.overallLength",
+              "operator": "greaterThan",
+              "value": 27.5
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Must be greater than 27.5m.",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.vehicleConfiguration.overallLength"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "vehicleConfiguration.frontProjection",
+              "operator": "greaterThan",
+              "value": 0
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Must be greater than 0m.",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.vehicleConfiguration.frontProjection"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "vehicleConfiguration.rearProjection",
+              "operator": "greaterThan",
+              "value": 0
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Must be greater than 0m.",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.vehicleConfiguration.rearProjection"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "vehicleConfiguration.overloadWeight",
+              "operator": "greaterThan",
+              "value": 0
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Must be greater than 0kg.",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.vehicleConfiguration.overloadWeight"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "vehicleDetails.vehicleSubType",
+              "operator": "in",
+              "value": {
+                "fact": "allowedVehicles"
+              }
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Vehicle type not permittable for this permit type",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.vehicleDetails.vehicleSubType"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "permittedRoute.manualRoute.origin",
+              "operator": "stringMinimumLength",
+              "value": 1
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Route origin is required",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.permittedRoute.manualRoute.origin"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "permittedRoute.manualRoute.destination",
+              "operator": "stringMinimumLength",
+              "value": 1
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Route destination is required",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.permittedRoute.manualRoute.origin"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "permittedRoute.manualRoute.totalDistance",
+              "operator": "greaterThan",
+              "value": 0
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Trip distance must be greater than zero",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.permittedRoute.manualRoute.totalDistance"
+            }
+          }
+        }
+      ],
+      "costRules": [
+        {
+          "fact": "fixedCost",
+          "params": {
+            "cost": 15,
+            "description": "Oversize"
+          }
+        },
+        {
+          "fact": "overloadWeightCost",
+          "params": {
+            "description": "Overload"
+          }
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "CVSE-1000",
+          "mandatory": true
+        },
+        {
+          "condition": "CVSE-1070",
+          "mandatory": true
+        }
+      ]
+    },
+    {
       "id": "STGVWI",
       "name": "Single Trip GVW Increase",
       "routingRequired": true,
@@ -1995,6 +2263,8 @@
         "OGSERVC",
         "OGSRRAH",
         "PICKRTT",
+        "TRCKPME",
+        "TRACPME",
         "PLOWBLD",
         "PUTAXIS",
         "REGTRCK",
@@ -2040,16 +2310,13 @@
               "fact": "permitData",
               "path": "vehicleConfiguration.actualGVW",
               "operator": "greaterThan",
-              "value": {
-                "fact": "permitData",
-                "path": "vehicleDetails.licensedGVW"
-              }
+              "value": 0
             }
           },
           "event": {
             "type": "violation",
             "params": {
-              "message": "Actual GVW must be greater than Licensed GVW.",
+              "message": "This is a required field",
               "code": "field-validation-error",
               "fieldReference": "permitData.vehicleConfiguration.actualGVW"
             }
@@ -2057,12 +2324,51 @@
         },
         {
           "conditions": {
-            "not": {
-              "fact": "permitData",
-              "path": "vehicleConfiguration.actualGVW",
-              "operator": "lessThanInclusive",
-              "value": 63500
+            "all": [
+              {
+                "fact": "permitData",
+                "path": "vehicleConfiguration.actualGVW",
+                "operator": "greaterThan",
+                "value": 0
+              },
+              {
+                "not": {
+                  "fact": "permitData",
+                  "path": "vehicleConfiguration.actualGVW",
+                  "operator": "greaterThan",
+                  "value": {
+                    "fact": "permitData",
+                    "path": "vehicleDetails.licensedGVW"
+                  }
+                }
+              }
+            ]
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Must be greater than Licensed GVW.",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.vehicleConfiguration.actualGVW"
             }
+          }
+        },
+        {
+          "conditions": {
+            "all": [
+              {
+                "fact": "permitData",
+                "path": "vehicleConfiguration.actualGVW",
+                "operator": "greaterThan",
+                "value": 0
+              },
+              {
+                "fact": "permitData",
+                "path": "vehicleConfiguration.actualGVW",
+                "operator": "greaterThan",
+                "value": 63500
+              }
+            ]
           },
           "event": {
             "type": "violation",
@@ -2072,11 +2378,85 @@
               "fieldReference": "permitData.vehicleConfiguration.actualGVW"
             }
           }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "vehicleDetails.vehicleSubType",
+              "operator": "in",
+              "value": {
+                "fact": "allowedVehicles"
+              }
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Vehicle type not permittable for this permit type",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.vehicleDetails.vehicleSubType"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "permittedRoute.manualRoute.origin",
+              "operator": "stringMinimumLength",
+              "value": 1
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Route origin is required",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.permittedRoute.manualRoute.origin"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "permittedRoute.manualRoute.destination",
+              "operator": "stringMinimumLength",
+              "value": 1
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Route destination is required",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.permittedRoute.manualRoute.origin"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "permittedRoute.manualRoute.totalDistance",
+              "operator": "greaterThan",
+              "value": 0
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Trip distance must be greater than zero",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.permittedRoute.manualRoute.totalDistance"
+            }
+          }
         }
       ],
       "costRules": [
         {
-          "fact": "overloadCost",
+          "fact": "overloadGvwCost",
           "params": {
             "description": "Calculates overload fee based on distance and licensed GVW increase"
           }

--- a/src/_examples/usage/node-backend-example/src/config/_current-config.json
+++ b/src/_examples/usage/node-backend-example/src/config/_current-config.json
@@ -2049,6 +2049,26 @@
         },
         {
           "conditions": {
+            "all": [
+              {
+                "fact": "permitData",
+                "path": "vehicleConfiguration.overallWidth",
+                "operator": "greaterThan",
+                "value": 3.2
+              }
+            ]
+          },
+          "event": {
+            "type": "warning",
+            "params": {
+              "message": "The provided dimensions make this application ineligible for self-issue and must be reviewed by the Provincial Permit Centre.",
+              "code": "dimension-oversize",
+              "fieldReference": "permitData.vehicleConfiguration.overallWidth"
+            }
+          }
+        },
+        {
+          "conditions": {
             "not": {
               "fact": "permitData",
               "path": "vehicleConfiguration.overallHeight",
@@ -2067,6 +2087,26 @@
         },
         {
           "conditions": {
+            "all": [
+              {
+                "fact": "permitData",
+                "path": "vehicleConfiguration.overallHeight",
+                "operator": "greaterThan",
+                "value": 4.3
+              }
+            ]
+          },
+          "event": {
+            "type": "warning",
+            "params": {
+              "message": "The provided dimensions make this application ineligible for self-issue and must be reviewed by the Provincial Permit Centre.",
+              "code": "dimension-oversize",
+              "fieldReference": "permitData.vehicleConfiguration.overallHeight"
+            }
+          }
+        },
+        {
+          "conditions": {
             "not": {
               "fact": "permitData",
               "path": "vehicleConfiguration.overallLength",
@@ -2079,6 +2119,26 @@
             "params": {
               "message": "Must be greater than 27.5m.",
               "code": "field-validation-error",
+              "fieldReference": "permitData.vehicleConfiguration.overallLength"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "all": [
+              {
+                "fact": "permitData",
+                "path": "vehicleConfiguration.overallLength",
+                "operator": "greaterThan",
+                "value": 31
+              }
+            ]
+          },
+          "event": {
+            "type": "warning",
+            "params": {
+              "message": "The provided dimensions make this application ineligible for self-issue and must be reviewed by the Provincial Permit Centre.",
+              "code": "dimension-oversize",
               "fieldReference": "permitData.vehicleConfiguration.overallLength"
             }
           }

--- a/src/_test/permit-app/valid-stwse.json
+++ b/src/_test/permit-app/valid-stwse.json
@@ -1,0 +1,77 @@
+{
+  "permitType": "STWSE",
+  "permitData": {
+    "companyName": "Sonic Delivery Services",
+    "clientNumber": "B3-000102-466",
+    "permitDuration": 7,
+    "commodities": [
+      {
+        "description": "General Permit Conditions",
+        "condition": "CVSE-1000",
+        "conditionLink": "https://www.th.gov.bc.ca/forms/getForm.aspx?formId=1251",
+        "checked": true,
+        "disabled": true
+      },
+      {
+        "description": "Permit Scope and Limitation",
+        "condition": "CVSE-1070",
+        "conditionLink": "https://www.th.gov.bc.ca/forms/getForm.aspx?formId=1261",
+        "checked": true,
+        "disabled": true
+      }
+    ],
+    "contactDetails": {
+      "firstName": "Chief",
+      "lastName": "Baker",
+      "phone1": "(250) 555-1234",
+      "phone1Extension": null,
+      "phone2": "(250) 555-4321",
+      "phone2Extension": null,
+      "email": "chief.baker@gov.bc.ca",
+      "additionalEmail": "baker.chief@gov.bc.ca",
+      "fax": null
+    },
+    "mailingAddress": {
+      "addressLine1": "940 Blanshard",
+      "addressLine2": null,
+      "city": "Victoria",
+      "provinceCode": "BC",
+      "countryCode": "CA",
+      "postalCode": "V8B1A2"
+    },
+    "vehicleDetails": {
+      "vehicleId": "101",
+      "unitNumber": "321",
+      "vin": "654321",
+      "plate": "D654321",
+      "make": "Kenworth",
+      "year": 2022,
+      "countryCode": "CA",
+      "provinceCode": "BC",
+      "vehicleType": "powerUnit",
+      "vehicleSubType": "TRKTRAC",
+      "saveVehicle": false
+    },
+    "vehicleConfiguration": {
+      "overallWidth": 1,
+      "overallHeight": 1,
+      "overallLength": 27.6,
+      "frontProjection": 1,
+      "rearProjection": 1,
+      "overloadWeight": 10000
+    },
+    "permittedRoute": {
+      "manualRoute": {
+        "origin": "Victoria, BC",
+        "destination": "Prince George, BC",
+        "highwaySequence": ["1", "5"],
+        "totalDistance": 800
+      },
+      "routeDetails": "STWSE test permit route details"
+    },
+    "feeSummary": "0",
+    "startDate": "2026-07-30",
+    "expiryDate": "2026-08-05",
+    "applicationNotes": "Policy Engine STWSE test"
+  }
+}

--- a/src/_test/policy-config/_current-config.json
+++ b/src/_test/policy-config/_current-config.json
@@ -2377,6 +2377,274 @@
       ]
     },
     {
+      "id": "STWSE",
+      "name": "Single Trip GVW Increase",
+      "routingRequired": true,
+      "weightDimensionRequired": true,
+      "sizeDimensionRequired": true,
+      "commodityRequired": false,
+      "allowedVehicles": [
+        "CONCRET",
+        "CRANEAT",
+        "CRANEMB",
+        "GRADERS",
+        "LWBTRCT",
+        "MUNFITR",
+        "OGBEDTK",
+        "OGOILSW",
+        "OGSERVC",
+        "OGSRRAH",
+        "PICKRTT",
+        "PICKRTR",
+        "RBTRLDR",
+        "TLSCONV",
+        "TOWVEHC",
+        "TRKTRAC",
+        "REGTRCK",
+        "TRCKPME",
+        "TRACPME"
+      ],
+      "rules": [
+        {
+          "conditions": {
+            "any": [
+              {
+                "not": {
+                  "fact": "permitData",
+                  "path": "permitDuration",
+                  "operator": "lessThanInclusive",
+                  "value": 7
+                }
+              },
+              {
+                "not": {
+                  "fact": "permitData",
+                  "path": "permitDuration",
+                  "operator": "greaterThan",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Duration must be 7 days or less",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.permitDuration"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "vehicleConfiguration.overallWidth",
+              "operator": "greaterThan",
+              "value": 0
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Must be greater than 0m.",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.vehicleConfiguration.overallWidth"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "vehicleConfiguration.overallHeight",
+              "operator": "greaterThan",
+              "value": 0
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Must be greater than 0m.",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.vehicleConfiguration.overallHeight"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "vehicleConfiguration.overallLength",
+              "operator": "greaterThan",
+              "value": 27.5
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Must be greater than 27.5m.",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.vehicleConfiguration.overallLength"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "vehicleConfiguration.frontProjection",
+              "operator": "greaterThan",
+              "value": 0
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Must be greater than 0m.",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.vehicleConfiguration.frontProjection"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "vehicleConfiguration.rearProjection",
+              "operator": "greaterThan",
+              "value": 0
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Must be greater than 0m.",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.vehicleConfiguration.rearProjection"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "vehicleConfiguration.overloadWeight",
+              "operator": "greaterThan",
+              "value": 0
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Must be greater than 0kg.",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.vehicleConfiguration.overloadWeight"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "vehicleDetails.vehicleSubType",
+              "operator": "in",
+              "value": {
+                "fact": "allowedVehicles"
+              }
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Vehicle type not permittable for this permit type",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.vehicleDetails.vehicleSubType"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "permittedRoute.manualRoute.origin",
+              "operator": "stringMinimumLength",
+              "value": 1
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Route origin is required",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.permittedRoute.manualRoute.origin"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "permittedRoute.manualRoute.destination",
+              "operator": "stringMinimumLength",
+              "value": 1
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Route destination is required",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.permittedRoute.manualRoute.origin"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "permittedRoute.manualRoute.totalDistance",
+              "operator": "greaterThan",
+              "value": 0
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Trip distance must be greater than zero",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.permittedRoute.manualRoute.totalDistance"
+            }
+          }
+        }
+      ],
+      "costRules": [
+        {
+          "fact": "fixedCost",
+          "params": {
+            "cost": 15,
+            "description": "Oversize"
+          }
+        },
+        {
+          "fact": "overloadWeightCost",
+          "params": {
+            "description": "Overload"
+          }
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "CVSE-1000",
+          "mandatory": true
+        },
+        {
+          "condition": "CVSE-1070",
+          "mandatory": true
+        }
+      ]
+    },
+    {
       "id": "STGVWI",
       "name": "Single Trip GVW Increase",
       "routingRequired": true,
@@ -2516,11 +2784,85 @@
               "fieldReference": "permitData.vehicleConfiguration.actualGVW"
             }
           }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "vehicleDetails.vehicleSubType",
+              "operator": "in",
+              "value": {
+                "fact": "allowedVehicles"
+              }
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Vehicle type not permittable for this permit type",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.vehicleDetails.vehicleSubType"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "permittedRoute.manualRoute.origin",
+              "operator": "stringMinimumLength",
+              "value": 1
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Route origin is required",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.permittedRoute.manualRoute.origin"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "permittedRoute.manualRoute.destination",
+              "operator": "stringMinimumLength",
+              "value": 1
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Route destination is required",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.permittedRoute.manualRoute.origin"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "not": {
+              "fact": "permitData",
+              "path": "permittedRoute.manualRoute.totalDistance",
+              "operator": "greaterThan",
+              "value": 0
+            }
+          },
+          "event": {
+            "type": "violation",
+            "params": {
+              "message": "Trip distance must be greater than zero",
+              "code": "field-validation-error",
+              "fieldReference": "permitData.permittedRoute.manualRoute.totalDistance"
+            }
+          }
         }
       ],
       "costRules": [
         {
-          "fact": "overloadCost",
+          "fact": "overloadGvwCost",
           "params": {
             "description": "Calculates overload fee based on distance and licensed GVW increase"
           }

--- a/src/_test/policy-config/_current-config.json
+++ b/src/_test/policy-config/_current-config.json
@@ -2455,6 +2455,26 @@
         },
         {
           "conditions": {
+            "all": [
+              {
+                "fact": "permitData",
+                "path": "vehicleConfiguration.overallWidth",
+                "operator": "greaterThan",
+                "value": 3.2
+              }
+            ]
+          },
+          "event": {
+            "type": "warning",
+            "params": {
+              "message": "The provided dimensions make this application ineligible for self-issue and must be reviewed by the Provincial Permit Centre.",
+              "code": "dimension-oversize",
+              "fieldReference": "permitData.vehicleConfiguration.overallWidth"
+            }
+          }
+        },
+        {
+          "conditions": {
             "not": {
               "fact": "permitData",
               "path": "vehicleConfiguration.overallHeight",
@@ -2473,6 +2493,26 @@
         },
         {
           "conditions": {
+            "all": [
+              {
+                "fact": "permitData",
+                "path": "vehicleConfiguration.overallHeight",
+                "operator": "greaterThan",
+                "value": 4.3
+              }
+            ]
+          },
+          "event": {
+            "type": "warning",
+            "params": {
+              "message": "The provided dimensions make this application ineligible for self-issue and must be reviewed by the Provincial Permit Centre.",
+              "code": "dimension-oversize",
+              "fieldReference": "permitData.vehicleConfiguration.overallHeight"
+            }
+          }
+        },
+        {
+          "conditions": {
             "not": {
               "fact": "permitData",
               "path": "vehicleConfiguration.overallLength",
@@ -2485,6 +2525,26 @@
             "params": {
               "message": "Must be greater than 27.5m.",
               "code": "field-validation-error",
+              "fieldReference": "permitData.vehicleConfiguration.overallLength"
+            }
+          }
+        },
+        {
+          "conditions": {
+            "all": [
+              {
+                "fact": "permitData",
+                "path": "vehicleConfiguration.overallLength",
+                "operator": "greaterThan",
+                "value": 31
+              }
+            ]
+          },
+          "event": {
+            "type": "warning",
+            "params": {
+              "message": "The provided dimensions make this application ineligible for self-issue and must be reviewed by the Provincial Permit Centre.",
+              "code": "dimension-oversize",
               "fieldReference": "permitData.vehicleConfiguration.overallLength"
             }
           }

--- a/src/_test/policy-config/_current-config.ts
+++ b/src/_test/policy-config/_current-config.ts
@@ -2390,6 +2390,274 @@ export const data: PolicyDefinition = {
       conditions: [],
     },
     {
+      id: 'STWSE',
+      name: 'Single Trip GVW Increase',
+      routingRequired: true,
+      weightDimensionRequired: true,
+      sizeDimensionRequired: true,
+      commodityRequired: false,
+      allowedVehicles: [
+        'CONCRET',
+        'CRANEAT',
+        'CRANEMB',
+        'GRADERS',
+        'LWBTRCT',
+        'MUNFITR',
+        'OGBEDTK',
+        'OGOILSW',
+        'OGSERVC',
+        'OGSRRAH',
+        'PICKRTT',
+        'PICKRTR',
+        'RBTRLDR',
+        'TLSCONV',
+        'TOWVEHC',
+        'TRKTRAC',
+        'REGTRCK',
+        'TRCKPME',
+        'TRACPME'
+      ],
+      rules: [
+        {
+          conditions: {
+            any: [
+              {
+                not: {
+                  fact: 'permitData',
+                  path: 'permitDuration',
+                  operator: 'lessThanInclusive',
+                  value: 7
+                }
+              },
+              {
+                not: {
+                  fact: 'permitData',
+                  path: 'permitDuration',
+                  operator: 'greaterThan',
+                  value: 0
+                }
+              }
+            ]
+          },
+          event: {
+            type: 'violation',
+            params: {
+              message: 'Duration must be 7 days or less',
+              code: 'field-validation-error',
+              fieldReference: 'permitData.permitDuration'
+            }
+          }
+        },
+        {
+          conditions: {
+            not: {
+              fact: 'permitData',
+              path: 'vehicleConfiguration.overallWidth',
+              operator: 'greaterThan',
+              value: 0
+            }
+          },
+          event: {
+            type: 'violation',
+            params: {
+              message: 'Must be greater than 0m.',
+              code: 'field-validation-error',
+              fieldReference: 'permitData.vehicleConfiguration.overallWidth'
+            }
+          }
+        },
+        {
+          conditions: {
+            not: {
+              fact: 'permitData',
+              path: 'vehicleConfiguration.overallHeight',
+              operator: 'greaterThan',
+              value: 0
+            }
+          },
+          event: {
+            type: 'violation',
+            params: {
+              message: 'Must be greater than 0m.',
+              code: 'field-validation-error',
+              fieldReference: 'permitData.vehicleConfiguration.overallHeight'
+            }
+          }
+        },
+        {
+          conditions: {
+            not: {
+              fact: 'permitData',
+              path: 'vehicleConfiguration.overallLength',
+              operator: 'greaterThan',
+              value: 27.5
+            }
+          },
+          event: {
+            type: 'violation',
+            params: {
+              message: 'Must be greater than 27.5m.',
+              code: 'field-validation-error',
+              fieldReference: 'permitData.vehicleConfiguration.overallLength'
+            }
+          }
+        },
+        {
+          conditions: {
+            not: {
+              fact: 'permitData',
+              path: 'vehicleConfiguration.frontProjection',
+              operator: 'greaterThan',
+              value: 0
+            }
+          },
+          event: {
+            type: 'violation',
+            params: {
+              message: 'Must be greater than 0m.',
+              code: 'field-validation-error',
+              fieldReference: 'permitData.vehicleConfiguration.frontProjection'
+            }
+          }
+        },
+        {
+          conditions: {
+            not: {
+              fact: 'permitData',
+              path: 'vehicleConfiguration.rearProjection',
+              operator: 'greaterThan',
+              value: 0
+            }
+          },
+          event: {
+            type: 'violation',
+            params: {
+              message: 'Must be greater than 0m.',
+              code: 'field-validation-error',
+              fieldReference: 'permitData.vehicleConfiguration.rearProjection'
+            }
+          }
+        },
+        {
+          conditions: {
+            not: {
+              fact: 'permitData',
+              path: 'vehicleConfiguration.overloadWeight',
+              operator: 'greaterThan',
+              value: 0
+            }
+          },
+          event: {
+            type: 'violation',
+            params: {
+              message: 'Must be greater than 0kg.',
+              code: 'field-validation-error',
+              fieldReference: 'permitData.vehicleConfiguration.overloadWeight'
+            }
+          }
+        },
+        {
+          conditions: {
+            not: {
+              fact: 'permitData',
+              path: 'vehicleDetails.vehicleSubType',
+              operator: 'in',
+              value: {
+                fact: 'allowedVehicles'
+              }
+            }
+          },
+          event: {
+            type: 'violation',
+            params: {
+              message: 'Vehicle type not permittable for this permit type',
+              code: 'field-validation-error',
+              fieldReference: 'permitData.vehicleDetails.vehicleSubType'
+            }
+          }
+        },
+        {
+          conditions: {
+            not: {
+              fact: 'permitData',
+              path: 'permittedRoute.manualRoute.origin',
+              operator: 'stringMinimumLength',
+              value: 1
+            }
+          },
+          event: {
+            type: 'violation',
+            params: {
+              message: 'Route origin is required',
+              code: 'field-validation-error',
+              fieldReference: 'permitData.permittedRoute.manualRoute.origin'
+            }
+          }
+        },
+        {
+          conditions: {
+            not: {
+              fact: 'permitData',
+              path: 'permittedRoute.manualRoute.destination',
+              operator: 'stringMinimumLength',
+              value: 1
+            }
+          },
+          event: {
+            type: 'violation',
+            params: {
+              message: 'Route destination is required',
+              code: 'field-validation-error',
+              fieldReference: 'permitData.permittedRoute.manualRoute.origin'
+            }
+          }
+        },
+        {
+          conditions: {
+            not: {
+              fact: 'permitData',
+              path: 'permittedRoute.manualRoute.totalDistance',
+              operator: 'greaterThan',
+              value: 0
+            }
+          },
+          event: {
+            type: 'violation',
+            params: {
+              message: 'Trip distance must be greater than zero',
+              code: 'field-validation-error',
+              fieldReference: 'permitData.permittedRoute.manualRoute.totalDistance'
+            }
+          }
+        }
+      ],
+      costRules: [
+        {
+          fact: 'fixedCost',
+          params: {
+            cost: 15,
+            description: 'Oversize'
+          }
+        },
+        {
+          fact: 'overloadWeightCost',
+          params: {
+            description: 'Overload'
+          }
+        }
+      ],
+      conditions: [
+        {
+          condition: 'CVSE-1000',
+          mandatory: true
+        },
+        {
+          condition: 'CVSE-1070',
+          mandatory: true
+        }
+      ]
+    },
+    {
       id: 'STGVWI',
       name: 'Single Trip GVW Increase',
       routingRequired: true,
@@ -2422,7 +2690,7 @@ export const data: PolicyDefinition = {
         'SCRAPER',
         'STINGER',
         'TOWVEHC',
-        'TRKTRAC',
+        'TRKTRAC'
       ],
       rules: [
         {
@@ -2433,27 +2701,27 @@ export const data: PolicyDefinition = {
                   fact: 'permitData',
                   path: 'permitDuration',
                   operator: 'lessThanInclusive',
-                  value: 7,
-                },
+                  value: 7
+                }
               },
               {
                 not: {
                   fact: 'permitData',
                   path: 'permitDuration',
                   operator: 'greaterThan',
-                  value: 0,
-                },
-              },
-            ],
+                  value: 0
+                }
+              }
+            ]
           },
           event: {
             type: 'violation',
             params: {
               message: 'Duration must be 7 days or less',
               code: 'field-validation-error',
-              fieldReference: 'permitData.permitDuration',
-            },
-          },
+              fieldReference: 'permitData.permitDuration'
+            }
+          }
         },
         {
           conditions: {
@@ -2461,55 +2729,164 @@ export const data: PolicyDefinition = {
               fact: 'permitData',
               path: 'vehicleConfiguration.actualGVW',
               operator: 'greaterThan',
-              value: {
-                fact: 'permitData',
-                path: 'vehicleDetails.licensedGVW',
-              },
-            },
+              value: 0
+            }
           },
           event: {
             type: 'violation',
             params: {
-              message: 'Actual GVW must be greater than Licensed GVW.',
+              message: 'This is a required field',
               code: 'field-validation-error',
-              fieldReference: 'permitData.vehicleConfiguration.actualGVW',
-            },
-          },
+              fieldReference: 'permitData.vehicleConfiguration.actualGVW'
+            }
+          }
         },
         {
           conditions: {
-            not: {
-              fact: 'permitData',
-              path: 'vehicleConfiguration.actualGVW',
-              operator: 'lessThanInclusive',
-              value: 63500,
-            },
+            all: [
+              {
+                fact: 'permitData',
+                path: 'vehicleConfiguration.actualGVW',
+                operator: 'greaterThan',
+                value: 0
+              },
+              {
+                not: {
+                  fact: 'permitData',
+                  path: 'vehicleConfiguration.actualGVW',
+                  operator: 'greaterThan',
+                  value: {
+                    fact: 'permitData',
+                    path: 'vehicleDetails.licensedGVW'
+                  }
+                }
+              }
+            ]
+          },
+          event: {
+            type: 'violation',
+            params: {
+              message: 'Must be greater than Licensed GVW.',
+              code: 'field-validation-error',
+              fieldReference: 'permitData.vehicleConfiguration.actualGVW'
+            }
+          }
+        },
+        {
+          conditions: {
+            all: [
+              {
+                fact: 'permitData',
+                path: 'vehicleConfiguration.actualGVW',
+                operator: 'greaterThan',
+                value: 0
+              },
+              {
+                fact: 'permitData',
+                path: 'vehicleConfiguration.actualGVW',
+                operator: 'greaterThan',
+                value: 63500
+              }
+            ]
           },
           event: {
             type: 'violation',
             params: {
               message: 'Cannot exceed 63,500kg',
               code: 'field-validation-error',
-              fieldReference: 'permitData.vehicleConfiguration.actualGVW',
-            },
-          },
+              fieldReference: 'permitData.vehicleConfiguration.actualGVW'
+            }
+          }
         },
+        {
+          conditions: {
+            not: {
+              fact: 'permitData',
+              path: 'vehicleDetails.vehicleSubType',
+              operator: 'in',
+              value: {
+                fact: 'allowedVehicles'
+              }
+            }
+          },
+          event: {
+            type: 'violation',
+            params: {
+              message: 'Vehicle type not permittable for this permit type',
+              code: 'field-validation-error',
+              fieldReference: 'permitData.vehicleDetails.vehicleSubType'
+            }
+          }
+        },
+        {
+          conditions: {
+            not: {
+              fact: 'permitData',
+              path: 'permittedRoute.manualRoute.origin',
+              operator: 'stringMinimumLength',
+              value: 1
+            }
+          },
+          event: {
+            type: 'violation',
+            params: {
+              message: 'Route origin is required',
+              code: 'field-validation-error',
+              fieldReference: 'permitData.permittedRoute.manualRoute.origin'
+            }
+          }
+        },
+        {
+          conditions: {
+            not: {
+              fact: 'permitData',
+              path: 'permittedRoute.manualRoute.destination',
+              operator: 'stringMinimumLength',
+              value: 1
+            }
+          },
+          event: {
+            type: 'violation',
+            params: {
+              message: 'Route destination is required',
+              code: 'field-validation-error',
+              fieldReference: 'permitData.permittedRoute.manualRoute.origin'
+            }
+          }
+        },
+        {
+          conditions: {
+            not: {
+              fact: 'permitData',
+              path: 'permittedRoute.manualRoute.totalDistance',
+              operator: 'greaterThan',
+              value: 0
+            }
+          },
+          event: {
+            type: 'violation',
+            params: {
+              message: 'Trip distance must be greater than zero',
+              code: 'field-validation-error',
+              fieldReference: 'permitData.permittedRoute.manualRoute.totalDistance'
+            }
+          }
+        }
       ],
       costRules: [
         {
-          fact: 'overloadCost',
+          fact: 'overloadGvwCost',
           params: {
-            description:
-              'Calculates overload fee based on distance and licensed GVW increase',
-          },
-        },
+            description: 'Calculates overload fee based on distance and licensed GVW increase'
+          }
+        }
       ],
       conditions: [
         {
           condition: 'CVSE-1070',
-          mandatory: true,
-        },
-      ],
+          mandatory: true
+        }
+      ]
     },
     {
       id: 'STFR',

--- a/src/_test/policy-config/_current-config.ts
+++ b/src/_test/policy-config/_current-config.ts
@@ -2468,6 +2468,26 @@ export const data: PolicyDefinition = {
         },
         {
           conditions: {
+            all: [
+              {
+                fact: 'permitData',
+                path: 'vehicleConfiguration.overallWidth',
+                operator: 'greaterThan',
+                value: 3.2
+              }
+            ]
+          },
+          event: {
+            type: 'warning',
+            params: {
+              message: 'The provided dimensions make this application ineligible for self-issue and must be reviewed by the Provincial Permit Centre.',
+              code: 'dimension-oversize',
+              fieldReference: 'permitData.vehicleConfiguration.overallWidth'
+            }
+          }
+        },
+        {
+          conditions: {
             not: {
               fact: 'permitData',
               path: 'vehicleConfiguration.overallHeight',
@@ -2486,6 +2506,26 @@ export const data: PolicyDefinition = {
         },
         {
           conditions: {
+            all: [
+              {
+                fact: 'permitData',
+                path: 'vehicleConfiguration.overallHeight',
+                operator: 'greaterThan',
+                value: 4.3
+              }
+            ]
+          },
+          event: {
+            type: 'warning',
+            params: {
+              message: 'The provided dimensions make this application ineligible for self-issue and must be reviewed by the Provincial Permit Centre.',
+              code: 'dimension-oversize',
+              fieldReference: 'permitData.vehicleConfiguration.overallHeight'
+            }
+          }
+        },
+        {
+          conditions: {
             not: {
               fact: 'permitData',
               path: 'vehicleConfiguration.overallLength',
@@ -2498,6 +2538,26 @@ export const data: PolicyDefinition = {
             params: {
               message: 'Must be greater than 27.5m.',
               code: 'field-validation-error',
+              fieldReference: 'permitData.vehicleConfiguration.overallLength'
+            }
+          }
+        },
+        {
+          conditions: {
+            all: [
+              {
+                fact: 'permitData',
+                path: 'vehicleConfiguration.overallLength',
+                operator: 'greaterThan',
+                value: 31
+              }
+            ]
+          },
+          event: {
+            type: 'warning',
+            params: {
+              message: 'The provided dimensions make this application ineligible for self-issue and must be reviewed by the Provincial Permit Centre.',
+              code: 'dimension-oversize',
               fieldReference: 'permitData.vehicleConfiguration.overallLength'
             }
           }

--- a/src/_test/unit/stwse-validation.spec.ts
+++ b/src/_test/unit/stwse-validation.spec.ts
@@ -1,0 +1,182 @@
+import { Policy } from 'onroute-policy-engine';
+import dayjs from 'dayjs';
+
+import { PermitAppInfo } from '../../enum/permit-app-info';
+import currentConfig from '../policy-config/_current-config.json';
+import validSTWSE from '../permit-app/valid-stwse.json';
+
+describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () => {
+  const policy: Policy = new Policy(currentConfig);
+
+  const getPermit = () => {
+    const permit = JSON.parse(JSON.stringify(validSTWSE));
+
+    const today = dayjs();
+    permit.permitData.startDate = today
+      .format(PermitAppInfo.PermitDateFormat);
+
+    permit.permitData.permitDuration = 7;
+    
+    permit.permitData.expiryDate = today
+      .add(6, "day")
+      .format(PermitAppInfo.PermitDateFormat);
+    
+    return permit;
+  };
+
+  it('should validate STWSE successfully', async () => {
+    const permit = getPermit();
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.violations).toHaveLength(0);
+  });
+
+  it('should fail validation when Overall Width is not provided', async () => {
+    const permit = getPermit();
+    permit.permitData.vehicleConfiguration.overallWidth = null;
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.violations).toHaveLength(1);
+  });
+
+  it('should fail validation when Overall Height is not provided', async () => {
+    const permit = getPermit();
+    permit.permitData.vehicleConfiguration.overallHeight = null;
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.violations).toHaveLength(1);
+  });
+
+  it('should fail validation when Overall Length is not provided', async () => {
+    const permit = getPermit();
+    permit.permitData.vehicleConfiguration.overallLength = null;
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.violations).toHaveLength(1);
+  });
+
+  it('should fail validation when Front Projection is not provided', async () => {
+    const permit = getPermit();
+    permit.permitData.vehicleConfiguration.frontProjection = null;
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.violations).toHaveLength(1);
+  });
+
+  it('should fail validation when Rear Projection is not provided', async () => {
+    const permit = getPermit();
+    permit.permitData.vehicleConfiguration.rearProjection = null;
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.violations).toHaveLength(1);
+  });
+
+  it('should fail validation when Weight over 27.5m is not provided', async () => {
+    const permit = getPermit();
+    permit.permitData.vehicleConfiguration.overloadWeight = null;
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.violations).toHaveLength(1);
+  });
+
+  it('should fail validation when Overall Width is not greater than 0', async () => {
+    const permit = getPermit();
+    permit.permitData.vehicleConfiguration.overallWidth = 0;
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.violations).toHaveLength(1);
+  });
+
+  it('should fail validation when Overall Height is not greater than 0', async () => {
+    const permit = getPermit();
+    permit.permitData.vehicleConfiguration.overallHeight = 0;
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.violations).toHaveLength(1);
+  });
+
+  it('should fail validation when Overall Length is not greater than 27.5m', async () => {
+    const permit = getPermit();
+    permit.permitData.vehicleConfiguration.overallLength = 25;
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.violations).toHaveLength(1);
+  });
+
+  it('should fail validation when Front Projection is not greater than 0', async () => {
+    const permit = getPermit();
+    permit.permitData.vehicleConfiguration.frontProjection = 0;
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.violations).toHaveLength(1);
+  });
+
+  it('should fail validation when Rear Projection is not greater than 0', async () => {
+    const permit = getPermit();
+    permit.permitData.vehicleConfiguration.rearProjection = 0;
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.violations).toHaveLength(1);
+  });
+
+  it('should fail validation when Weight over 27.5m is not greater than 0', async () => {
+    const permit = getPermit();
+    permit.permitData.vehicleConfiguration.overloadWeight = 0;
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.violations).toHaveLength(1);
+  });
+
+  it('should fail validation when Total Distance is not provided', async () => {
+    const permit = getPermit();
+    permit.permitData.permittedRoute.manualRoute.totalDistance = null;
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.violations).toHaveLength(1);
+  });
+
+  it('should fail validation when Total Distance is not greater than 0', async () => {
+    const permit = getPermit();
+    permit.permitData.permittedRoute.manualRoute.totalDistance = 0;
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.violations).toHaveLength(1);
+  });
+
+  it('should fail validation when Vehicle subtype is not part of allowable vehicles', async () => {
+    const permit = getPermit();
+    permit.permitData.vehicleDetails.vehicleSubType = "BUSCRUM";
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.violations).toHaveLength(1);
+  });
+
+  it('should pass when Vehicle subtype is part of allowable vehicles', async () => {
+    const permit = getPermit();
+    permit.permitData.vehicleDetails.vehicleSubType = "LWBTRCT";
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.violations).toHaveLength(0);
+  });
+
+  it('should fail validation when Vehicle subtype is a Trailer', async () => {
+    const permit = getPermit();
+    permit.permitData.vehicleDetails.vehicleType = "trailer";
+    permit.permitData.vehicleDetails.vehicleSubType = "FULLLTL";
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.violations).toHaveLength(1);
+  });
+
+  it('should return only mandatory CVSE-1000 and CVSE-1070 for STWSE conditions', () => {
+    const permit = getPermit();
+
+    const conditions = policy.getConditionsForPermit(permit);
+    expect(conditions).toHaveLength(2);
+    expect(conditions[0].condition).toBe('CVSE-1000');
+    expect(conditions[0].mandatory).toBe(true);
+    expect(conditions[1].condition).toBe('CVSE-1070');
+    expect(conditions[1].mandatory).toBe(true);
+  });
+
+  it('should calculate STWSE cost as a flat $15 flat rate plus overload rate', async () => {
+    const permit = getPermit();
+
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.cost.length).toBe(2);
+    expect(validationResult.cost[0].cost).toBe(15.00);
+    expect(validationResult.cost[1].cost).toBe(268.00);
+  });
+
+  it('should calculate STWSE cost as a flat $15 flat rate plus minimum of $25 overload fee', async () => {
+    const permit = getPermit();
+    permit.permitData.vehicleConfiguration.overloadWeight = 1000;
+    permit.permitData.permittedRoute.manualRoute.totalDistance = 100;
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.cost.length).toBe(2);
+    expect(validationResult.cost[0].cost).toBe(15.00);
+    expect(validationResult.cost[1].cost).toBe(25.00);
+  });
+});

--- a/src/_test/unit/stwse-validation.spec.ts
+++ b/src/_test/unit/stwse-validation.spec.ts
@@ -179,4 +179,14 @@ describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () =>
     expect(validationResult.cost[0].cost).toBe(15.00);
     expect(validationResult.cost[1].cost).toBe(25.00);
   });
+
+  it('should calculate STWSE cost as a flat $15 flat rate plus overload fee above 28000kg', async () => {
+    const permit = getPermit();
+    permit.permitData.vehicleConfiguration.overloadWeight = 30700;
+    permit.permitData.permittedRoute.manualRoute.totalDistance = 100;
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.cost.length).toBe(2);
+    expect(validationResult.cost[0].cost).toBe(15.00);
+    expect(validationResult.cost[1].cost).toBe(270.00);
+  });
 });

--- a/src/_test/unit/stwse-validation.spec.ts
+++ b/src/_test/unit/stwse-validation.spec.ts
@@ -173,10 +173,13 @@ describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () =>
 
     const conditions = policy.getConditionsForPermit(permit);
     expect(conditions).toHaveLength(2);
-    expect(conditions[0].condition).toBe('CVSE-1000');
-    expect(conditions[0].mandatory).toBe(true);
-    expect(conditions[1].condition).toBe('CVSE-1070');
-    expect(conditions[1].mandatory).toBe(true);
+    expect(conditions.filter(
+      condition => condition.condition === 'CVSE-1000' && condition.mandatory === true
+    )).toHaveLength(1);
+
+    expect(conditions.filter(
+      condition => condition.condition === 'CVSE-1070' && condition.mandatory === true
+    )).toHaveLength(1);
   });
 
   it('should calculate STWSE cost as a flat $15 oversize rate plus overload rate', async () => {

--- a/src/_test/unit/stwse-validation.spec.ts
+++ b/src/_test/unit/stwse-validation.spec.ts
@@ -28,6 +28,7 @@ describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () =>
     const permit = getPermit();
     const validationResult = await policy.validate(permit);
     expect(validationResult.violations).toHaveLength(0);
+    expect(validationResult.warnings).toHaveLength(0);
   });
 
   it('should fail validation when Overall Width is not provided', async () => {
@@ -35,6 +36,7 @@ describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () =>
     permit.permitData.vehicleConfiguration.overallWidth = null;
     const validationResult = await policy.validate(permit);
     expect(validationResult.violations).toHaveLength(1);
+    expect(validationResult.warnings).toHaveLength(0);
   });
 
   it('should fail validation when Overall Height is not provided', async () => {
@@ -42,6 +44,7 @@ describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () =>
     permit.permitData.vehicleConfiguration.overallHeight = null;
     const validationResult = await policy.validate(permit);
     expect(validationResult.violations).toHaveLength(1);
+    expect(validationResult.warnings).toHaveLength(0);
   });
 
   it('should fail validation when Overall Length is not provided', async () => {
@@ -49,6 +52,7 @@ describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () =>
     permit.permitData.vehicleConfiguration.overallLength = null;
     const validationResult = await policy.validate(permit);
     expect(validationResult.violations).toHaveLength(1);
+    expect(validationResult.warnings).toHaveLength(0);
   });
 
   it('should fail validation when Front Projection is not provided', async () => {
@@ -56,6 +60,7 @@ describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () =>
     permit.permitData.vehicleConfiguration.frontProjection = null;
     const validationResult = await policy.validate(permit);
     expect(validationResult.violations).toHaveLength(1);
+    expect(validationResult.warnings).toHaveLength(0);
   });
 
   it('should fail validation when Rear Projection is not provided', async () => {
@@ -63,6 +68,7 @@ describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () =>
     permit.permitData.vehicleConfiguration.rearProjection = null;
     const validationResult = await policy.validate(permit);
     expect(validationResult.violations).toHaveLength(1);
+    expect(validationResult.warnings).toHaveLength(0);
   });
 
   it('should fail validation when Weight over 27.5m is not provided', async () => {
@@ -70,6 +76,7 @@ describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () =>
     permit.permitData.vehicleConfiguration.overloadWeight = null;
     const validationResult = await policy.validate(permit);
     expect(validationResult.violations).toHaveLength(1);
+    expect(validationResult.warnings).toHaveLength(0);
   });
 
   it('should fail validation when Overall Width is not greater than 0', async () => {
@@ -77,6 +84,7 @@ describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () =>
     permit.permitData.vehicleConfiguration.overallWidth = 0;
     const validationResult = await policy.validate(permit);
     expect(validationResult.violations).toHaveLength(1);
+    expect(validationResult.warnings).toHaveLength(0);
   });
 
   it('should fail validation when Overall Height is not greater than 0', async () => {
@@ -84,6 +92,7 @@ describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () =>
     permit.permitData.vehicleConfiguration.overallHeight = 0;
     const validationResult = await policy.validate(permit);
     expect(validationResult.violations).toHaveLength(1);
+    expect(validationResult.warnings).toHaveLength(0);
   });
 
   it('should fail validation when Overall Length is not greater than 27.5m', async () => {
@@ -91,6 +100,7 @@ describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () =>
     permit.permitData.vehicleConfiguration.overallLength = 25;
     const validationResult = await policy.validate(permit);
     expect(validationResult.violations).toHaveLength(1);
+    expect(validationResult.warnings).toHaveLength(0);
   });
 
   it('should fail validation when Front Projection is not greater than 0', async () => {
@@ -98,6 +108,7 @@ describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () =>
     permit.permitData.vehicleConfiguration.frontProjection = 0;
     const validationResult = await policy.validate(permit);
     expect(validationResult.violations).toHaveLength(1);
+    expect(validationResult.warnings).toHaveLength(0);
   });
 
   it('should fail validation when Rear Projection is not greater than 0', async () => {
@@ -105,6 +116,7 @@ describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () =>
     permit.permitData.vehicleConfiguration.rearProjection = 0;
     const validationResult = await policy.validate(permit);
     expect(validationResult.violations).toHaveLength(1);
+    expect(validationResult.warnings).toHaveLength(0);
   });
 
   it('should fail validation when Weight over 27.5m is not greater than 0', async () => {
@@ -112,6 +124,7 @@ describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () =>
     permit.permitData.vehicleConfiguration.overloadWeight = 0;
     const validationResult = await policy.validate(permit);
     expect(validationResult.violations).toHaveLength(1);
+    expect(validationResult.warnings).toHaveLength(0);
   });
 
   it('should fail validation when Total Distance is not provided', async () => {
@@ -119,6 +132,7 @@ describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () =>
     permit.permitData.permittedRoute.manualRoute.totalDistance = null;
     const validationResult = await policy.validate(permit);
     expect(validationResult.violations).toHaveLength(1);
+    expect(validationResult.warnings).toHaveLength(0);
   });
 
   it('should fail validation when Total Distance is not greater than 0', async () => {
@@ -126,6 +140,7 @@ describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () =>
     permit.permitData.permittedRoute.manualRoute.totalDistance = 0;
     const validationResult = await policy.validate(permit);
     expect(validationResult.violations).toHaveLength(1);
+    expect(validationResult.warnings).toHaveLength(0);
   });
 
   it('should fail validation when Vehicle subtype is not part of allowable vehicles', async () => {
@@ -133,6 +148,7 @@ describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () =>
     permit.permitData.vehicleDetails.vehicleSubType = "BUSCRUM";
     const validationResult = await policy.validate(permit);
     expect(validationResult.violations).toHaveLength(1);
+    expect(validationResult.warnings).toHaveLength(0);
   });
 
   it('should pass when Vehicle subtype is part of allowable vehicles', async () => {
@@ -140,6 +156,7 @@ describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () =>
     permit.permitData.vehicleDetails.vehicleSubType = "LWBTRCT";
     const validationResult = await policy.validate(permit);
     expect(validationResult.violations).toHaveLength(0);
+    expect(validationResult.warnings).toHaveLength(0);
   });
 
   it('should fail validation when Vehicle subtype is a Trailer', async () => {
@@ -148,6 +165,7 @@ describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () =>
     permit.permitData.vehicleDetails.vehicleSubType = "FULLLTL";
     const validationResult = await policy.validate(permit);
     expect(validationResult.violations).toHaveLength(1);
+    expect(validationResult.warnings).toHaveLength(0);
   });
 
   it('should return only mandatory CVSE-1000 and CVSE-1070 for STWSE conditions', () => {
@@ -161,16 +179,18 @@ describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () =>
     expect(conditions[1].mandatory).toBe(true);
   });
 
-  it('should calculate STWSE cost as a flat $15 flat rate plus overload rate', async () => {
+  it('should calculate STWSE cost as a flat $15 oversize rate plus overload rate', async () => {
     const permit = getPermit();
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.cost.length).toBe(2);
     expect(validationResult.cost[0].cost).toBe(15.00);
     expect(validationResult.cost[1].cost).toBe(268.00);
+    expect(validationResult.cost[0].message).toBe("Oversize");
+    expect(validationResult.cost[1].message).toBe("Overload");
   });
 
-  it('should calculate STWSE cost as a flat $15 flat rate plus minimum of $25 overload fee', async () => {
+  it('should calculate STWSE cost as a flat $15 oversize rate plus minimum of $25 overload fee', async () => {
     const permit = getPermit();
     permit.permitData.vehicleConfiguration.overloadWeight = 1000;
     permit.permitData.permittedRoute.manualRoute.totalDistance = 100;
@@ -180,7 +200,7 @@ describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () =>
     expect(validationResult.cost[1].cost).toBe(25.00);
   });
 
-  it('should calculate STWSE cost as a flat $15 flat rate plus overload fee above 28000kg', async () => {
+  it('should calculate STWSE cost as a flat $15 oversize rate plus overload fee above 28000kg', async () => {
     const permit = getPermit();
     permit.permitData.vehicleConfiguration.overloadWeight = 30700;
     permit.permitData.permittedRoute.manualRoute.totalDistance = 100;
@@ -188,5 +208,58 @@ describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () =>
     expect(validationResult.cost.length).toBe(2);
     expect(validationResult.cost[0].cost).toBe(15.00);
     expect(validationResult.cost[1].cost).toBe(270.00);
+  });
+
+  it('should calculate STWSE costs to be $0 for oversize and overload if no-fee flag is set', async () => {
+    const permit = getPermit();
+    const noFeePolicy = new Policy(
+      currentConfig,
+      {
+        companyId: 1,
+        isLcvAllowed: false,
+        noFeeType: "CA_GOVT",
+      },
+    );
+
+    const validationResult = await noFeePolicy.validate(permit);
+    expect(validationResult.cost.length).toBe(2);
+    expect(validationResult.cost[0].cost).toBe(0);
+    expect(validationResult.cost[1].cost).toBe(0);
+    expect(validationResult.cost[0].message).toBe("Oversize");
+    expect(validationResult.cost[1].message).toBe("Overload");
+  });
+
+  it('should show warning when overall width is greater than 3.2m', async () => {
+    const permit = getPermit();
+    permit.permitData.vehicleConfiguration.overallWidth = 3.3;
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.violations).toHaveLength(0);
+    expect(validationResult.warnings).toHaveLength(1);
+  });
+
+  it('should show warning when overall length is greater than 31m', async () => {
+    const permit = getPermit();
+    permit.permitData.vehicleConfiguration.overallLength = 31.1;
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.violations).toHaveLength(0);
+    expect(validationResult.warnings).toHaveLength(1);
+  });
+
+  it('should show warning when overall height is greater than 4.3m', async () => {
+    const permit = getPermit();
+    permit.permitData.vehicleConfiguration.overallHeight = 4.4;
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.violations).toHaveLength(0);
+    expect(validationResult.warnings).toHaveLength(1);
+  });
+
+  it('should show multiple warnings and violations when there are multiple oversized dimensions', async () => {
+    const permit = getPermit();
+    permit.permitData.vehicleConfiguration.overallHeight = 5;
+    permit.permitData.vehicleConfiguration.overallWidth = 4;
+    permit.permitData.vehicleConfiguration.overallLength = 25;
+    const validationResult = await policy.validate(permit);
+    expect(validationResult.violations).toHaveLength(1);
+    expect(validationResult.warnings).toHaveLength(2);
   });
 });

--- a/src/constants/cost.ts
+++ b/src/constants/cost.ts
@@ -1,0 +1,8 @@
+/**
+ * This is the default description used for each cost object,
+ * when there is no explicit description provided (eg. Non-STWSE permit costs).
+ * 
+ * NOTE: DO NOT change the value of this constant, as the value is being used elsewhere
+ * throughout the backend.
+ */
+export const DEFAULT_COST_DESCRIPTION = 'Calculated permit cost';

--- a/src/constants/overload.ts
+++ b/src/constants/overload.ts
@@ -1,0 +1,36 @@
+export const BASE_OVERLOAD_LIMIT = 28000;
+export const EXTRA_WEIGHT_INTERVAL = 900;
+export const EXTRA_RATE_INCREMENT = 1.85;
+export const DEFAULT_MAX_RATE = 21.4;
+export const MINIMUM_OVERLOAD_FEE = 25;
+
+// Overload permit fee rate table mapping up to 28,000 kg
+export const OVERLOAD_RATES_PER_10KM = [
+  { max: 2000, rate: 0.95 },
+  { max: 3000, rate: 1.15 },
+  { max: 4000, rate: 1.4 },
+  { max: 5000, rate: 1.6 },
+  { max: 6000, rate: 1.85 },
+  { max: 7000, rate: 2.15 },
+  { max: 8000, rate: 2.45 },
+  { max: 9000, rate: 2.95 },
+  { max: 10000, rate: 3.35 },
+  { max: 11000, rate: 3.75 },
+  { max: 12000, rate: 4.25 },
+  { max: 13000, rate: 4.95 },
+  { max: 14000, rate: 5.6 },
+  { max: 15000, rate: 6.25 },
+  { max: 16000, rate: 7.25 },
+  { max: 17000, rate: 8.25 },
+  { max: 18000, rate: 9.15 },
+  { max: 19000, rate: 10.1 },
+  { max: 20000, rate: 10.9 },
+  { max: 21000, rate: 11.85 },
+  { max: 22000, rate: 12.7 },
+  { max: 23000, rate: 13.95 },
+  { max: 24000, rate: 14.95 },
+  { max: 25000, rate: 16.1 },
+  { max: 26000, rate: 17.85 },
+  { max: 27000, rate: 19.85 },
+  { max: 28000, rate: 21.4 },
+];

--- a/src/constants/stgvwi.ts
+++ b/src/constants/stgvwi.ts
@@ -1,6 +1,1 @@
 export const AXLE_CALC_RESULTS_FACT = 'axleCalcResults';
-export const BASE_OVERLOAD_LIMIT = 28000;
-export const EXTRA_WEIGHT_INTERVAL = 900;
-export const EXTRA_RATE_INCREMENT = 1.85;
-export const DEFAULT_MAX_RATE = 21.4;
-export const MINIMUM_OVERLOAD_FEE = 25;

--- a/src/enum/facts.ts
+++ b/src/enum/facts.ts
@@ -18,6 +18,7 @@ export enum CostFacts {
   CostPerKilometre = 'costPerKilometre',
   CostPerMonth = 'costPerMonth',
   FixedCost = 'fixedCost',
-  OverloadCost = 'overloadCost',
+  OverloadGvwCost = 'overloadGvwCost',
+  OverloadWeightCost = 'overloadWeightCost',
   RangeMatrixCostLookup = 'rangeMatrixCostLookup',
 }

--- a/src/enum/validation-result-code.ts
+++ b/src/enum/validation-result-code.ts
@@ -4,6 +4,7 @@ export enum ValidationResultCode {
   PolicyValidationError = 'policy-validation-error',
   ConfigurationInvalid = 'configuration-invalid',
   GeneralResult = 'general-result',
+  DimensionOversize = 'dimension-oversize',
   CostValue = 'cost-value',
   IsLcvCarrier = 'lcv-carrier',
   NoFeeClient = 'no-fee-client',

--- a/src/helper/facts.helper.ts
+++ b/src/helper/facts.helper.ts
@@ -1,13 +1,14 @@
 import dayjs from 'dayjs';
 import quarterOfYear from 'dayjs/plugin/quarterOfYear';
 import { Engine } from 'json-rules-engine';
+import { Policy } from 'onroute-policy-engine';
 import {
   PermitAppInfo,
   PolicyFacts,
   CostFacts,
   PolicyCheckResultType,
 } from 'onroute-policy-engine/enum';
-import { Policy } from 'onroute-policy-engine';
+
 import {
   AxleCalcResults,
   AxleConfiguration,
@@ -16,15 +17,17 @@ import {
   RangeMatrix,
   VehicleConfiguration,
 } from 'onroute-policy-engine/types';
+
 import { policyCheckMap } from './policy-check.helper';
+import { AXLE_CALC_RESULTS_FACT } from '../constants/stgvwi';
 import {
-  AXLE_CALC_RESULTS_FACT,
   BASE_OVERLOAD_LIMIT,
   DEFAULT_MAX_RATE,
   EXTRA_RATE_INCREMENT,
   EXTRA_WEIGHT_INTERVAL,
   MINIMUM_OVERLOAD_FEE,
-} from '../constants/stgvwi';
+  OVERLOAD_RATES_PER_10KM,
+} from '../constants/overload';
 
 dayjs.extend(quarterOfYear);
 
@@ -70,6 +73,32 @@ const getAxleCalculationInputs = async (
     axleConfiguration,
     licensedGVW: vehicleDetails.licensedGVW || 0,
   };
+};
+
+const getOverloadCost = (overloadKg: number, totalDistance: number) => {
+  let ratePer10km = 0;
+
+  if (overloadKg <= BASE_OVERLOAD_LIMIT) {
+    const match = OVERLOAD_RATES_PER_10KM.find((r) => overloadKg <= r.max);
+    ratePer10km = match ? match.rate : DEFAULT_MAX_RATE;
+  } else {
+    // For overload greater than BASE_OVERLOAD_LIMIT kg
+    const extraWeight = overloadKg - BASE_OVERLOAD_LIMIT;
+    const intervals = Math.ceil(extraWeight / EXTRA_WEIGHT_INTERVAL);
+    ratePer10km = DEFAULT_MAX_RATE + intervals * EXTRA_RATE_INCREMENT;
+  }
+
+  // Fee calculation: rate * (totalDistance / 10)
+  const distanceUnits = Math.ceil(totalDistance / 10);
+  let totalFee = ratePer10km * distanceUnits;
+
+  // Apply minimum fee rule
+  if (totalFee < MINIMUM_OVERLOAD_FEE) {
+    totalFee = MINIMUM_OVERLOAD_FEE;
+  }
+
+  // Round to the nearest dollar (0.50 rounds up)
+  return Math.round(totalFee);
 };
 
 /**
@@ -536,7 +565,7 @@ export function addRuntimeFacts(engine: Engine, policy: Policy): void {
    * based on the Licensed GVW Increase and Total Distance.
    */
   engine.addFact(
-    CostFacts.OverloadCost.toString(),
+    CostFacts.OverloadGvwCost.toString(),
     async function (params, almanac) {
       const actualGVW: number = await almanac.factValue(
         PermitAppInfo.PermitData,
@@ -559,59 +588,34 @@ export function addRuntimeFacts(engine: Engine, policy: Policy): void {
         return 0;
       }
 
-      let ratePer10km = 0;
+      return getOverloadCost(overloadKg, distance);
+    },
+  );
 
-      if (overloadKg <= BASE_OVERLOAD_LIMIT) {
-        // Overload permit fee rate table mapping up to 28,000 kg
-        const rates = [
-          { max: 2000, rate: 0.95 },
-          { max: 3000, rate: 1.15 },
-          { max: 4000, rate: 1.4 },
-          { max: 5000, rate: 1.6 },
-          { max: 6000, rate: 1.85 },
-          { max: 7000, rate: 2.15 },
-          { max: 8000, rate: 2.45 },
-          { max: 9000, rate: 2.95 },
-          { max: 10000, rate: 3.35 },
-          { max: 11000, rate: 3.75 },
-          { max: 12000, rate: 4.25 },
-          { max: 13000, rate: 4.95 },
-          { max: 14000, rate: 5.6 },
-          { max: 15000, rate: 6.25 },
-          { max: 16000, rate: 7.25 },
-          { max: 17000, rate: 8.25 },
-          { max: 18000, rate: 9.15 },
-          { max: 19000, rate: 10.1 },
-          { max: 20000, rate: 10.9 },
-          { max: 21000, rate: 11.85 },
-          { max: 22000, rate: 12.7 },
-          { max: 23000, rate: 13.95 },
-          { max: 24000, rate: 14.95 },
-          { max: 25000, rate: 16.1 },
-          { max: 26000, rate: 17.85 },
-          { max: 27000, rate: 19.85 },
-          { max: 28000, rate: 21.4 },
-        ];
+  /**
+   * Add runtime fact to calculate the overload fee for STWSE permits
+   * based on the Weight over 27.5m and Total Distance.
+   */
+  engine.addFact(
+    CostFacts.OverloadWeightCost.toString(),
+    async function (params, almanac) {
+      const overloadWeight: number = await almanac.factValue(
+        PermitAppInfo.PermitData,
+        {},
+        'vehicleConfiguration.overloadWeight',
+      );
 
-        const match = rates.find((r) => overloadKg <= r.max);
-        ratePer10km = match ? match.rate : DEFAULT_MAX_RATE;
-      } else {
-        // For overload greater than BASE_OVERLOAD_LIMIT kg
-        const extraWeight = overloadKg - BASE_OVERLOAD_LIMIT;
-        const intervals = Math.ceil(extraWeight / EXTRA_WEIGHT_INTERVAL);
-        ratePer10km = DEFAULT_MAX_RATE + intervals * EXTRA_RATE_INCREMENT;
+      const totalDistance: number = await almanac.factValue(
+        PermitAppInfo.PermitData,
+        {},
+        PermitAppInfo.TotalDistance,
+      );
+
+      if (overloadWeight <= 0 || !totalDistance) {
+        return 0;
       }
 
-      // Fee calculation: rate * (distance / 10)
-      const distanceUnits = Math.ceil(distance / 10);
-      let totalFee = ratePer10km * distanceUnits;
-
-      // Apply minimum fee rule
-      if (totalFee < MINIMUM_OVERLOAD_FEE) {
-        totalFee = MINIMUM_OVERLOAD_FEE;
-      }
-      // Round to the nearest dollar (0.50 rounds up)
-      return Math.round(totalFee);
+      return getOverloadCost(overloadWeight, totalDistance);
     },
   );
 }

--- a/src/helper/rules-engine.helper.ts
+++ b/src/helper/rules-engine.helper.ts
@@ -53,7 +53,7 @@ export function getRulesEngines(policy: Policy): Map<string, Engine> {
         event: {
           type: 'cost',
           params: {
-            message: 'Calculated permit cost',
+            message: c.params.description || 'Calculated permit cost',
             code: 'cost-value',
             cost: c,
           },

--- a/src/helper/rules-engine.helper.ts
+++ b/src/helper/rules-engine.helper.ts
@@ -1,7 +1,9 @@
 import { Engine, RuleProperties } from 'json-rules-engine';
-import { CustomOperators } from '../rule-operator/custom-operators';
 import { Policy } from 'onroute-policy-engine';
 import { PolicyDefinition } from 'onroute-policy-engine/types';
+
+import { CustomOperators } from '../rule-operator/custom-operators';
+import { DEFAULT_COST_DESCRIPTION } from '../constants/cost';
 
 /**
  * Gets a json-rules-engine with all onRouteBC custom operators added,
@@ -53,7 +55,7 @@ export function getRulesEngines(policy: Policy): Map<string, Engine> {
         event: {
           type: 'cost',
           params: {
-            message: c.params.description || 'Calculated permit cost',
+            message: c.params.description || DEFAULT_COST_DESCRIPTION,
             code: 'cost-value',
             cost: c,
           },

--- a/src/policy-engine.ts
+++ b/src/policy-engine.ts
@@ -67,6 +67,7 @@ import {
   CheckNumberOfAxles,
   policyCheckMap,
 } from './helper/policy-check.helper';
+import { DEFAULT_COST_DESCRIPTION } from './constants/cost';
 
 /** Class representing commercial vehicle policy. */
 export class Policy {
@@ -197,7 +198,7 @@ export class Policy {
           const newPermitCostResult = new ValidationResult(
             ValidationResultType.Cost,
             ValidationResultCode.CostValue,
-            'Calculated permit cost',
+            DEFAULT_COST_DESCRIPTION,
           );
           newPermitCostResult.cost = 0;
           validationResults.cost.push(newPermitCostResult);

--- a/src/policy-engine.ts
+++ b/src/policy-engine.ts
@@ -191,15 +191,30 @@ export class Policy {
           0,
         );
 
-        // Clear the cost array and replace with zero cost
-        validationResults.cost.length = 0;
-        const newPermitCostResult = new ValidationResult(
-          ValidationResultType.Cost,
-          ValidationResultCode.CostValue,
-          'Calculated permit cost',
-        );
-        newPermitCostResult.cost = 0;
-        validationResults.cost.push(newPermitCostResult);
+        if (permit.permitType !== "STWSE") {
+          // Clear the cost array and replace with zero cost
+          validationResults.cost.length = 0;
+          const newPermitCostResult = new ValidationResult(
+            ValidationResultType.Cost,
+            ValidationResultCode.CostValue,
+            'Calculated permit cost',
+          );
+          newPermitCostResult.cost = 0;
+          validationResults.cost.push(newPermitCostResult);
+        } else {
+          // If permit type is STWSE, keep each of the cost objects, but set their costs to zero
+          const newPermitCosts = validationResults.cost.map(cost => {
+            const newPermitCostResult = new ValidationResult(
+              ValidationResultType.Cost,
+              ValidationResultCode.CostValue,
+              cost.message,
+            );
+            newPermitCostResult.cost = 0;
+            return newPermitCostResult;
+          });
+
+          validationResults.cost = newPermitCosts;
+        }
 
         // Add an informational message to the results
         validationResults.information.push(


### PR DESCRIPTION
- Add STWSE related config to policy engine, which includes validation rules, specific warnings for oversize dimensions, and distinct costs for each of oversize and overload components
- Add and refactor cost calculation logic for overload rate (specific to STWSE and STGVWI)
- Add minor missing validation rules to STGVWI config
- Add tests for STWSE permit validation
- Update policy rules and no-fee cost calculation to accommodate STWSE permit type's separate-component costs (ie. both Oversize and Overload costs rather than the previous single cost object containing just the total cost).