### PR TITLE
fix: Use all datetimes in Policy Engine in Pacific timezone

### DIFF
--- a/src/_examples/calculate-cost.ts
+++ b/src/_examples/calculate-cost.ts
@@ -1,20 +1,31 @@
 import { Policy } from 'onroute-policy-engine';
 import { PermitAppInfo } from 'onroute-policy-engine/enum';
+
 import masterPolicyConfig from '../_test/policy-config/master.sample.json';
 import validTros30Day from '../_test/permit-app/valid-tros-30day.json';
-import dayjs from 'dayjs';
+import {
+  convertToTimezone,
+  getUtcDatetime,
+  TIMEZONE_IDS,
+} from '../helper/date.helper';
 
 async function start() {
   const policy: Policy = new Policy(masterPolicyConfig);
-  const today = dayjs();
+  const today = convertToTimezone(
+    getUtcDatetime(),
+    TIMEZONE_IDS.PACIFIC,
+  );
 
   // Set startDate to today
   validTros30Day.permitData.startDate = today.format(
     PermitAppInfo.PermitDateFormat.toString(),
   );
+
   // Set duration to full year (365 or 366 depending on leap year)
   const oneYearDuration: number = today.add(1, 'year').diff(today, 'day');
+
   console.log('Setting TROS permit duration to ' + oneYearDuration);
+  
   validTros30Day.permitData.permitDuration = oneYearDuration;
 
   const validationResult2 = await policy.validate(validTros30Day);

--- a/src/_examples/usage/node-backend-example/src/services/permitService.ts
+++ b/src/_examples/usage/node-backend-example/src/services/permitService.ts
@@ -1,10 +1,10 @@
 import { Policy } from 'onroute-policy-engine';
 import { ValidationResults } from 'onroute-policy-engine';
 import { PermitAppInfo } from 'onroute-policy-engine/enum';
-import dayjs from 'dayjs';
 
 // Use require for JSON import to avoid TypeScript module resolution issues
 const completePolicyConfig = require('../config/_current-config.json');
+const dateHelper = require('../utils/date.helper');
 
 let policyInstance: Policy | null = null;
 
@@ -36,7 +36,10 @@ export const validatePermit = async (
         ...permitData.permitData,
         startDate:
           permitData.permitData?.startDate ||
-          dayjs().format(PermitAppInfo.PermitDateFormat.toString()),
+          dateHelper.convertToTimezone(
+            dateHelper.getUtcDatetime(),
+            dateHelper.TIMEZONE_IDS.PACIFIC,
+          ).format(PermitAppInfo.PermitDateFormat.toString()),
       },
     };
 

--- a/src/_examples/usage/node-backend-example/src/utils/date.helper.ts
+++ b/src/_examples/usage/node-backend-example/src/utils/date.helper.ts
@@ -1,0 +1,51 @@
+import dayjs, { Dayjs } from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+import duration from 'dayjs/plugin/duration';
+import quarterOfYear from 'dayjs/plugin/quarterOfYear';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.extend(duration);
+dayjs.extend(quarterOfYear);
+
+export const TIMEZONE_IDS = {
+  PACIFIC: 'Canada/Pacific',
+};
+
+export const DATE_FORMATS = {
+  DATE_ONLY: 'YYYY-MM-DD',
+  DATETIME: 'YYYY-MM-DD HH:mm:ss',
+};
+
+/**
+ * Convert a datetime to a specified timezone.
+ * 
+ * @param datetime Datetime to be converted
+ * @param timezoneId Timezone identifier (eg. 'Canada/Pacific')
+ * @returns Dayjs object in the specified timezone
+ */
+export const convertToTimezone = (
+  datetime: string | Dayjs | Date,
+  timezoneId: string,
+) => {
+  return dayjs.tz(datetime, timezoneId);
+};
+
+/**
+ * Get UTC datetime.
+ * 
+ * @returns Dayjs object representing datetime in UTC
+ */
+export const getUtcDatetime = (datetime?: Dayjs | Date | string) => {
+  return dayjs.utc(datetime);
+};
+
+/**
+ * Get datetime representing the end of the quarter for a given datetime.
+ * @param datetime Datetime being used for reference
+ * @returns Dayjs object representing the end of the quarter for the inputted datetime
+ */
+export const getEndOfQuarter = (datetime: Dayjs) => {
+  return datetime.endOf('quarter');
+};

--- a/src/_examples/usage/react-frontend-example/src/App.tsx
+++ b/src/_examples/usage/react-frontend-example/src/App.tsx
@@ -2,10 +2,16 @@ import { useState, useEffect } from 'react'
 import { Policy } from 'onroute-policy-engine'
 import { ValidationResults, ValidationResult } from 'onroute-policy-engine'
 import { PermitAppInfo } from 'onroute-policy-engine/enum'
-import dayjs from 'dayjs'
+
 import PageHeader from './components/PageHeader'
 import PermitForm from './components/PermitForm'
 import VehicleFontTest from './components/VehicleFontTest'
+import {
+  convertToTimezone,
+  TIMEZONE_IDS,
+  getUtcDatetime,
+} from './helpers/date.helper';
+
 import './App.css'
 
 const API_BASE_URL = 'http://localhost:3001/api/permits'
@@ -16,8 +22,6 @@ function App() {
   const [permitApplication, setPermitApplication] = useState<any>(null)
   const [loading, setLoading] = useState(true)
   const [activeTab, setActiveTab] = useState<'form' | 'font-test'>('form')
-
-
 
   useEffect(() => {
     const initializePolicy = async () => {
@@ -137,7 +141,11 @@ function App() {
         },
         
         // Dates
-        startDate: permitData.startDate || dayjs().format(PermitAppInfo.PermitDateFormat.toString()),
+        startDate: permitData.startDate || convertToTimezone(
+          getUtcDatetime(),
+          TIMEZONE_IDS.PACIFIC,
+        ).format(PermitAppInfo.PermitDateFormat.toString()),
+
         expiryDate: permitData.expiryDate || null,
         
         // Additional fields
@@ -149,12 +157,17 @@ function App() {
         permittedRoute: {
           manualRoute: {
             highwaySequence: permitData.highwaySequence 
-              ? permitData.highwaySequence.split(',').map((h: string) => h.trim()).filter((h: string) => h.length > 0)
+              ? permitData.highwaySequence
+                .split(',')
+                .map((h: string) => h.trim())
+                .filter((h: string) => h.length > 0)
               : [],
             origin: permitData.routeOrigin,
             destination: permitData.routeDestination,
             exitPoint: permitData.routeExitPoint || null,
-            totalDistance: permitData.routeTotalDistance ? parseFloat(permitData.routeTotalDistance) : null
+            totalDistance: permitData.routeTotalDistance
+              ? parseFloat(permitData.routeTotalDistance)
+              : null
           },
           routeDetails: null
         },

--- a/src/_examples/usage/react-frontend-example/src/helpers/date.helper.ts
+++ b/src/_examples/usage/react-frontend-example/src/helpers/date.helper.ts
@@ -1,0 +1,51 @@
+import dayjs, { Dayjs } from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+import duration from 'dayjs/plugin/duration';
+import quarterOfYear from 'dayjs/plugin/quarterOfYear';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.extend(duration);
+dayjs.extend(quarterOfYear);
+
+export const TIMEZONE_IDS = {
+  PACIFIC: 'Canada/Pacific',
+};
+
+export const DATE_FORMATS = {
+  DATE_ONLY: 'YYYY-MM-DD',
+  DATETIME: 'YYYY-MM-DD HH:mm:ss',
+};
+
+/**
+ * Convert a datetime to a specified timezone.
+ * 
+ * @param datetime Datetime to be converted
+ * @param timezoneId Timezone identifier (eg. 'Canada/Pacific')
+ * @returns Dayjs object in the specified timezone
+ */
+export const convertToTimezone = (
+  datetime: string | Dayjs | Date,
+  timezoneId: string,
+) => {
+  return dayjs.tz(datetime, timezoneId);
+};
+
+/**
+ * Get UTC datetime.
+ * 
+ * @returns Dayjs object representing datetime in UTC
+ */
+export const getUtcDatetime = (datetime?: Dayjs | Date | string) => {
+  return dayjs.utc(datetime);
+};
+
+/**
+ * Get datetime representing the end of the quarter for a given datetime.
+ * @param datetime Datetime being used for reference
+ * @returns Dayjs object representing the end of the quarter for the inputted datetime
+ */
+export const getEndOfQuarter = (datetime: Dayjs) => {
+  return datetime.endOf('quarter');
+};

--- a/src/_examples/validate-hc.ts
+++ b/src/_examples/validate-hc.ts
@@ -1,14 +1,22 @@
 import { Policy } from 'onroute-policy-engine';
 import { PermitAppInfo } from 'onroute-policy-engine/enum';
+
 import hcOnly from '../_test/policy-config/_current-config.json';
 import validHc from '../_test/permit-app/valid-hcp.json';
-import dayjs from 'dayjs';
+import {
+  convertToTimezone,
+  getUtcDatetime,
+  TIMEZONE_IDS,
+} from '../helper/date.helper';
 
 async function start() {
   const policy: Policy = new Policy(hcOnly);
 
   // Set startDate to today
-  const today = dayjs();
+  const today = convertToTimezone(
+    getUtcDatetime(),
+    TIMEZONE_IDS.PACIFIC,
+  );
 
   validHc.permitData.startDate = today.format(
     PermitAppInfo.PermitDateFormat.toString(),

--- a/src/_examples/validate-invalid-tros.ts
+++ b/src/_examples/validate-invalid-tros.ts
@@ -1,14 +1,22 @@
 import { Policy } from 'onroute-policy-engine';
 import { PermitAppInfo } from 'onroute-policy-engine/enum';
+
 import masterPolicyConfig from '../_test/policy-config/master.sample.json';
 import validTros30Day from '../_test/permit-app/valid-tros-30day.json';
-import dayjs from 'dayjs';
+import {
+  convertToTimezone,
+  getUtcDatetime,
+  TIMEZONE_IDS,
+} from '../helper/date.helper';
 
 async function start() {
   const policy: Policy = new Policy(masterPolicyConfig);
 
   // Set startDate to today
-  validTros30Day.permitData.startDate = dayjs().format(
+  validTros30Day.permitData.startDate = convertToTimezone(
+    getUtcDatetime(),
+    TIMEZONE_IDS.PACIFIC,
+  ).format(
     PermitAppInfo.PermitDateFormat.toString(),
   );
 

--- a/src/_examples/validate-lcv.ts
+++ b/src/_examples/validate-lcv.ts
@@ -1,18 +1,27 @@
 import { Policy } from 'onroute-policy-engine';
 import { PermitAppInfo } from 'onroute-policy-engine/enum';
+
 import trosOnly from '../_test/policy-config/tros-only.sample.json';
 import specialAuth from '../_test/policy-config/special-auth-lcv.sample.json';
 import validTros30Day from '../_test/permit-app/valid-tros-30day.json';
-import dayjs from 'dayjs';
+import {
+  convertToTimezone,
+  getUtcDatetime,
+  TIMEZONE_IDS,
+} from '../helper/date.helper';
 
 async function start() {
   const policy: Policy = new Policy(trosOnly, specialAuth);
 
   // Set startDate to today
-  validTros30Day.permitData.startDate = dayjs().format(
+  validTros30Day.permitData.startDate = convertToTimezone(
+    getUtcDatetime(),
+    TIMEZONE_IDS.PACIFIC,
+  ).format(
     PermitAppInfo.PermitDateFormat.toString(),
   );
-  // Set an lcv vehicle type
+
+  // Set an LCV vehicle type
   validTros30Day.permitData.vehicleDetails.vehicleSubType = 'LCVRMDB';
 
   const validationResult2 = await policy.validate(validTros30Day);

--- a/src/_examples/validate-stos.ts
+++ b/src/_examples/validate-stos.ts
@@ -1,14 +1,22 @@
 import { Policy } from 'onroute-policy-engine';
 import { PermitAppInfo } from 'onroute-policy-engine/enum';
+
 import completePolicyConfig from '../_test/policy-config/_current-config.json';
 import testStos from '../_test/permit-app/test-stos.json';
-import dayjs from 'dayjs';
+import {
+  convertToTimezone,
+  getUtcDatetime,
+  TIMEZONE_IDS,
+} from '../helper/date.helper';
 
 async function start() {
   const policy: Policy = new Policy(completePolicyConfig);
 
   // Set startDate to today
-  testStos.permitData.startDate = dayjs().format(
+  testStos.permitData.startDate = convertToTimezone(
+    getUtcDatetime(),
+    TIMEZONE_IDS.PACIFIC,
+  ).format(
     PermitAppInfo.PermitDateFormat.toString(),
   );
 

--- a/src/_examples/validate-tros.ts
+++ b/src/_examples/validate-tros.ts
@@ -1,14 +1,22 @@
 import { Policy } from 'onroute-policy-engine';
 import { PermitAppInfo } from 'onroute-policy-engine/enum';
+
 import masterPolicyConfig from '../_test/policy-config/master.sample.json';
 import validTros30Day from '../_test/permit-app/valid-tros-30day.json';
-import dayjs from 'dayjs';
+import {
+  convertToTimezone,
+  getUtcDatetime,
+  TIMEZONE_IDS,
+} from '../helper/date.helper';
 
 async function start() {
   const policy: Policy = new Policy(masterPolicyConfig);
 
   // Set startDate to today
-  validTros30Day.permitData.startDate = dayjs().format(
+  validTros30Day.permitData.startDate = convertToTimezone(
+    getUtcDatetime(),
+    TIMEZONE_IDS.PACIFIC,
+  ).format(
     PermitAppInfo.PermitDateFormat.toString(),
   );
 

--- a/src/_test/unit/axle-calc.spec.ts
+++ b/src/_test/unit/axle-calc.spec.ts
@@ -1,4 +1,5 @@
-import { Policy } from '../../policy-engine';
+import { Policy } from 'onroute-policy-engine';
+
 import currentPolicyConfig from '../policy-config/_current-config.json';
 import testStow from '../permit-app/test-stow.json';
 import {
@@ -6,11 +7,13 @@ import {
   PolicyCheckId,
   PolicyCheckResultType,
 } from '../../enum';
+
 import {
   AxleCalcResults,
   AxleConfiguration,
   AxleGroupPolicyCheckResult,
 } from '../../types';
+
 import {
   CheckBoosterAxleLimit,
   CheckNumTiresPerAxle,
@@ -21,15 +24,22 @@ import {
   CheckWheelbaseLegalLimits,
   CheckDriveJeepLoadEqualization,
 } from '../../helper/policy-check.helper';
-import dayjs from 'dayjs';
+
+import {
+  convertToTimezone,
+  getUtcDatetime,
+  TIMEZONE_IDS,
+} from '../../helper/date.helper';
 
 describe('Axle Calculation Functions', () => {
   const policy: Policy = new Policy(currentPolicyConfig);
   const permit = JSON.parse(JSON.stringify(testStow));
+
   const vehicleConfiguration = policy.getSimplifiedVehicleConfiguration(
     permit.permitData.vehicleDetails,
     permit.permitData.vehicleConfiguration,
   );
+
   const axleConfiguration =
     permit.permitData.vehicleConfiguration.axleConfiguration;
 
@@ -40,6 +50,7 @@ describe('Axle Calculation Functions', () => {
     const ac = JSON.parse(
       JSON.stringify(axleConfiguration),
     ) as Array<AxleConfiguration>;
+
     ac[0].numberOfAxles = 1;
     ac[1].numberOfAxles = 2;
     ac[1].axleSpread = axleSpread;
@@ -52,12 +63,18 @@ describe('Axle Calculation Functions', () => {
     axleSpread: number,
   ) => {
     const p = JSON.parse(JSON.stringify(testStow));
-    p.permitData.startDate = dayjs().format(
+
+    p.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
+
     p.permitData.vehicleDetails.vehicleSubType = 'TRKTRAC';
     p.permitData.vehicleConfiguration.axleConfiguration =
       getTruckTractorWheelbaseAxles(interaxleSpacing, axleSpread);
+    
     p.permitData.vehicleConfiguration.axleConfiguration[0].axleUnitWeight = 6000;
     return p;
   };

--- a/src/_test/unit/axle-group-legal-weight.spec.ts
+++ b/src/_test/unit/axle-group-legal-weight.spec.ts
@@ -1,18 +1,25 @@
-import dayjs from 'dayjs';
-import { Policy } from '../../policy-engine';
+import { Policy } from 'onroute-policy-engine';
+
 import {
   PermitAppInfo,
   PolicyCheckId,
   PolicyCheckResultType,
 } from '../../enum';
+
 import { AxleConfiguration } from '../../types';
 import {
   CheckAxleGroupMaximumLegalWeightThreshold,
   getMaximumLegalAxleGroupWeightThreshold,
 } from '../../helper/policy-check.helper';
+
 import { getCtr717TableValue } from '../../helper/ctr-717.helper';
 import currentPolicyConfig from '../policy-config/_current-config.json';
 import testStow from '../permit-app/test-stow.json';
+import {
+  convertToTimezone,
+  getUtcDatetime,
+  TIMEZONE_IDS,
+} from '../../helper/date.helper';
 
 describe('ORV2-5617 axle group maximum legal weight threshold', () => {
   const policy = new Policy(currentPolicyConfig);
@@ -438,11 +445,16 @@ describe('ORV2-5617 axle group maximum legal weight threshold', () => {
 
     const getNestedJeepPermit = (driveWeight: number, jeepWeight: number) => {
       const permit = JSON.parse(JSON.stringify(testStow));
-      permit.permitData.startDate = dayjs().format(
+      permit.permitData.startDate = convertToTimezone(
+        getUtcDatetime(),
+        TIMEZONE_IDS.PACIFIC,
+      ).format(
         PermitAppInfo.PermitDateFormat.toString(),
       );
+
       const axleConfiguration =
         permit.permitData.vehicleConfiguration.axleConfiguration;
+      
       axleConfiguration[0].axleUnitWeight = 6000;
       axleConfiguration[1].axleUnitWeight = driveWeight;
       axleConfiguration[1].numberOfTires = 8;
@@ -453,17 +465,22 @@ describe('ORV2-5617 axle group maximum legal weight threshold', () => {
         interaxleSpacing: 155,
         axleUnitWeight: jeepWeight,
       };
+
       permit.permitData.vehicleConfiguration.axleConfiguration =
         axleConfiguration.slice(0, 2);
+      
       permit.permitData.vehicleConfiguration.trailers[0].axleConfiguration = [
         axleConfiguration[2],
       ];
+
       permit.permitData.vehicleConfiguration.trailers[1].axleConfiguration = [
         axleConfiguration[3],
       ];
+
       permit.permitData.vehicleConfiguration.trailers[2].axleConfiguration = [
         axleConfiguration[4],
       ];
+
       return permit;
     };
 

--- a/src/_test/unit/cost.spec.ts
+++ b/src/_test/unit/cost.spec.ts
@@ -1,15 +1,20 @@
 import { Policy } from 'onroute-policy-engine';
+
 import currentConfig from '../policy-config/_current-config.json';
 import multipleCostRules from '../policy-config/tros-multiple-cost-rules.sample.json';
 import validTros30Day from '../permit-app/valid-tros-30day.json';
 import validTrow120Day from '../permit-app/valid-trow-120day.json';
 import testStos from '../permit-app/test-stos.json';
 import invalidStos from '../permit-app/invalid-stos.json';
-import dayjs from 'dayjs';
 import specialAuthNoFee from '../policy-config/special-auth-nofee.sample.json';
 import specialAuthLcv from '../policy-config/special-auth-lcv.sample.json';
 import { PermitAppInfo } from '../../enum/permit-app-info';
 import { ValidationResultCode } from '../../enum';
+import {
+  convertToTimezone,
+  getUtcDatetime,
+  TIMEZONE_IDS,
+} from '../../helper/date.helper';
 
 describe('Policy Engine Cost Calculator', () => {
   const policy: Policy = new Policy(currentConfig);
@@ -17,8 +22,12 @@ describe('Policy Engine Cost Calculator', () => {
 
   it('should calculate 30 day TROS cost correctly', async () => {
     const permit = JSON.parse(JSON.stringify(validTros30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -30,8 +39,12 @@ describe('Policy Engine Cost Calculator', () => {
   it('should respect the no fee flag', async () => {
     const noFeePolicy = new Policy(currentConfig, specialAuthNoFee);
     const permit = JSON.parse(JSON.stringify(validTros30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -46,11 +59,15 @@ describe('Policy Engine Cost Calculator', () => {
 
   it('should calculate 31 day TROS cost as 2 months', async () => {
     const permit = JSON.parse(JSON.stringify(validTros30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    // Set duration to 31
+    
     permit.permitData.permitDuration = 31;
 
     const validationResult = await policy.validate(permit);
@@ -60,11 +77,16 @@ describe('Policy Engine Cost Calculator', () => {
 
   it('should calculate 1 year TROS cost correctly', async () => {
     const permit = JSON.parse(JSON.stringify(validTros30Day));
-    const today = dayjs();
+    const today = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     // Set startDate to today
     permit.permitData.startDate = today.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
+
     // Set duration to full year (365 or 366 depending on leap year)
     const oneYearDuration: number = today.add(1, 'year').diff(today, 'day');
     permit.permitData.permitDuration = oneYearDuration;
@@ -76,8 +98,12 @@ describe('Policy Engine Cost Calculator', () => {
 
   it('should calculate 120 day TROW cost correctly', async () => {
     const permit = JSON.parse(JSON.stringify(validTrow120Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -88,8 +114,12 @@ describe('Policy Engine Cost Calculator', () => {
 
   it('should calculate STOS cost correctly', async () => {
     const permit = JSON.parse(JSON.stringify(testStos));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -100,10 +130,15 @@ describe('Policy Engine Cost Calculator', () => {
 
   it('should not throw error when validating STOS', async () => {
     const permit = JSON.parse(JSON.stringify(invalidStos));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
+
     const validationResult = await policy.validate(permit);
     expect(validationResult.cost).toHaveLength(1);
     expect(validationResult.cost[0].cost).toBe(15);
@@ -112,10 +147,15 @@ describe('Policy Engine Cost Calculator', () => {
   it('should not throw error when validating STOS (with LCV auth)', async () => {
     const lcvPolicy = new Policy(currentConfig, specialAuthLcv);
     const permit = JSON.parse(JSON.stringify(invalidStos));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
+
     const validationResult = await lcvPolicy.validate(permit);
     expect(validationResult.cost).toHaveLength(1);
     expect(validationResult.cost[0].cost).toBe(15);
@@ -123,13 +163,18 @@ describe('Policy Engine Cost Calculator', () => {
 
   it('should calculate valid TROS with multiple cost rules correctly', async () => {
     const permit = JSON.parse(JSON.stringify(validTros30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
     const validationResult = await multipleCostRulesPolicy.validate(permit);
     expect(validationResult.cost).toHaveLength(2);
+
     const cost1: number = validationResult.cost[0]?.cost ?? 0;
     const cost2: number = validationResult.cost[1]?.cost ?? 0;
     expect(cost1 + cost2).toBe(45);
@@ -137,15 +182,20 @@ describe('Policy Engine Cost Calculator', () => {
 
   it('should calculate 31 day TROS with multiple cost rules correctly', async () => {
     const permit = JSON.parse(JSON.stringify(validTros30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    // Set duration to 31
+    
     permit.permitData.permitDuration = 31;
 
     const validationResult = await multipleCostRulesPolicy.validate(permit);
     expect(validationResult.cost).toHaveLength(2);
+    
     const cost1: number = validationResult.cost[0]?.cost ?? 0;
     const cost2: number = validationResult.cost[1]?.cost ?? 0;
     expect(cost1 + cost2).toBe(75);

--- a/src/_test/unit/hc-validation.spec.ts
+++ b/src/_test/unit/hc-validation.spec.ts
@@ -1,9 +1,13 @@
 import { Policy } from 'onroute-policy-engine';
-import dayjs from 'dayjs';
 
 import currentConfig from '../policy-config/_current-config.json';
 import validHc from '../permit-app/valid-hcp.json';
 import { PermitAppInfo } from '../../enum/permit-app-info';
+import {
+  convertToTimezone,
+  getUtcDatetime,
+  TIMEZONE_IDS,
+} from '../../helper/date.helper';
 
 describe('Highway Crossing Permit (HC) Validation Tests', () => {
   const policy: Policy = new Policy(currentConfig);
@@ -11,7 +15,11 @@ describe('Highway Crossing Permit (HC) Validation Tests', () => {
   const getPermit = () => {
     const permit = JSON.parse(JSON.stringify(validHc));
 
-    const today = dayjs();
+    const today = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = today
       .format(PermitAppInfo.PermitDateFormat);
     
@@ -36,6 +44,7 @@ describe('Highway Crossing Permit (HC) Validation Tests', () => {
       (total, result) => total + (result.cost ?? 0),
       0,
     );
+    
     expect(cost).toBe(30);
   });
 

--- a/src/_test/unit/mfp-validation.spec.ts
+++ b/src/_test/unit/mfp-validation.spec.ts
@@ -1,19 +1,28 @@
 import { Policy } from 'onroute-policy-engine';
+
 import currentConfig from '../policy-config/_current-config.json';
 import validMFP from '../permit-app/valid-mfp.json';
-import dayjs from 'dayjs';
 import { PermitAppInfo } from '../../enum/permit-app-info';
+import {
+  convertToTimezone,
+  getUtcDatetime,
+  TIMEZONE_IDS,
+} from '../../helper/date.helper';
 
 describe('Motive Fuel User Permit (MFP) Validator', () => {
   const policy: Policy = new Policy(currentConfig);
 
   it('should validate MFP successfully', async () => {
     const permit = JSON.parse(JSON.stringify(validMFP));
+
     // Set startDate to today
     // Note: we do not need to set the expiry date as well because
     // the validation only uses permitDuration, not expiryDate for this
     // permit type.
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -23,12 +32,15 @@ describe('Motive Fuel User Permit (MFP) Validator', () => {
 
   it('should validate MFP successfully with 6 day duration', async () => {
     const permit = JSON.parse(JSON.stringify(validMFP));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set duration to 6
     permit.permitData.permitDuration = 6;
 
     const validationResult = await policy.validate(permit);
@@ -37,12 +49,15 @@ describe('Motive Fuel User Permit (MFP) Validator', () => {
 
   it('should validate MFP successfully with 7 day duration', async () => {
     const permit = JSON.parse(JSON.stringify(validMFP));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set duration to 7
     permit.permitData.permitDuration = 7;
 
     const validationResult = await policy.validate(permit);
@@ -51,12 +66,15 @@ describe('Motive Fuel User Permit (MFP) Validator', () => {
 
   it('should fail validation for MFP with 8 day duration', async () => {
     const permit = JSON.parse(JSON.stringify(validMFP));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set duration to 8
     permit.permitData.permitDuration = 8;
 
     const validationResult = await policy.validate(permit);
@@ -65,12 +83,15 @@ describe('Motive Fuel User Permit (MFP) Validator', () => {
 
   it('should fail validation for MFP with 0 day duration', async () => {
     const permit = JSON.parse(JSON.stringify(validMFP));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set duration to 0
     permit.permitData.permitDuration = 0;
 
     const validationResult = await policy.validate(permit);
@@ -79,12 +100,15 @@ describe('Motive Fuel User Permit (MFP) Validator', () => {
 
   it('should fail validation for MFP with licensed GVW greater than 63,500', async () => {
     const permit = JSON.parse(JSON.stringify(validMFP));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set licensedGVW to 63501
     permit.permitData.vehicleDetails.licensedGVW = 63501;
 
     const validationResult = await policy.validate(permit);
@@ -93,12 +117,15 @@ describe('Motive Fuel User Permit (MFP) Validator', () => {
 
   it('should fail validation for MFP with licensed GVW of zero', async () => {
     const permit = JSON.parse(JSON.stringify(validMFP));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set licensedGVW to 0
     permit.permitData.vehicleDetails.licensedGVW = 0;
 
     const validationResult = await policy.validate(permit);
@@ -107,12 +134,15 @@ describe('Motive Fuel User Permit (MFP) Validator', () => {
 
   it('should fail validation for MFP with negative licensed GVW', async () => {
     const permit = JSON.parse(JSON.stringify(validMFP));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set licensedGVW to -1000
     permit.permitData.vehicleDetails.licensedGVW = -1000;
 
     const validationResult = await policy.validate(permit);
@@ -121,12 +151,15 @@ describe('Motive Fuel User Permit (MFP) Validator', () => {
 
   it('should pass validation for MFP with licensed GVW exactly 63,500', async () => {
     const permit = JSON.parse(JSON.stringify(validMFP));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set licensedGVW to 63500
     permit.permitData.vehicleDetails.licensedGVW = 63500;
 
     const validationResult = await policy.validate(permit);
@@ -135,12 +168,15 @@ describe('Motive Fuel User Permit (MFP) Validator', () => {
 
   it('should pass validation for MFP with licensed GVW 1 kg', async () => {
     const permit = JSON.parse(JSON.stringify(validMFP));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set licensedGVW to 1
     permit.permitData.vehicleDetails.licensedGVW = 1;
 
     const validationResult = await policy.validate(permit);
@@ -149,12 +185,15 @@ describe('Motive Fuel User Permit (MFP) Validator', () => {
 
   it('should fail validation for MFP with no origin address', async () => {
     const permit = JSON.parse(JSON.stringify(validMFP));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Clear origin
     permit.permitData.permittedRoute.manualRoute.origin = '';
 
     const validationResult = await policy.validate(permit);
@@ -163,12 +202,15 @@ describe('Motive Fuel User Permit (MFP) Validator', () => {
 
   it('should fail validation for MFP with no destination address', async () => {
     const permit = JSON.parse(JSON.stringify(validMFP));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Clear destination
     permit.permitData.permittedRoute.manualRoute.destination = '';
 
     const validationResult = await policy.validate(permit);
@@ -177,77 +219,101 @@ describe('Motive Fuel User Permit (MFP) Validator', () => {
 
   it('should calculate MFP cost correctly over minimum value', async () => {
     const permit = JSON.parse(JSON.stringify(validMFP));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    // Set distance to 200
+    
     permit.permitData.permittedRoute.manualRoute.totalDistance = 200;
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.cost).not.toHaveLength(0);
+
     const initialValue: number = 0;
     const cost = validationResult.cost.reduce(
       (prev: any, curr: any) => prev + curr.cost,
       initialValue,
     );
+
     expect(cost).toBe(14);
   });
 
   it('should calculate MFP cost correctly with fractional dollar amount', async () => {
     const permit = JSON.parse(JSON.stringify(validMFP));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    // Set distance to 750
+    
     permit.permitData.permittedRoute.manualRoute.totalDistance = 750;
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.cost).not.toHaveLength(0);
+
     const initialValue: number = 0;
     const cost = validationResult.cost.reduce(
       (prev: any, curr: any) => prev + curr.cost,
       initialValue,
     );
+
     expect(cost).toBe(53);
   });
 
   it('should calculate MFP cost correctly under minimum value', async () => {
     const permit = JSON.parse(JSON.stringify(validMFP));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    // Set distance to 180
+    
     permit.permitData.permittedRoute.manualRoute.totalDistance = 100;
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.cost).not.toHaveLength(0);
+
     const initialValue: number = 0;
     const cost = validationResult.cost.reduce(
       (prev: any, curr: any) => prev + curr.cost,
       initialValue,
     );
+
     expect(cost).toBe(10);
   });
 
   it('should calculate MFP cost correctly over maximum value', async () => {
     const permit = JSON.parse(JSON.stringify(validMFP));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    // Set distance to 2500
+    
     permit.permitData.permittedRoute.manualRoute.totalDistance = 2500;
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.cost).not.toHaveLength(0);
+
     const initialValue: number = 0;
     const cost = validationResult.cost.reduce(
       (prev: any, curr: any) => prev + curr.cost,
       initialValue,
     );
+    
     expect(cost).toBe(140);
   });
 });

--- a/src/_test/unit/nrqcv-validation.spec.ts
+++ b/src/_test/unit/nrqcv-validation.spec.ts
@@ -1,24 +1,32 @@
 import { Policy } from 'onroute-policy-engine';
+
 import currentConfig from '../policy-config/_current-config.json';
 import validNrqcv from '../permit-app/valid-nrqcv.json';
-import dayjs from 'dayjs';
-import quarterOfYear from 'dayjs/plugin/quarterOfYear';
 import { PermitAppInfo } from '../../enum/permit-app-info';
-
-dayjs.extend(quarterOfYear);
+import {
+  convertToTimezone,
+  getEndOfQuarter,
+  getUtcDatetime,
+  TIMEZONE_IDS,
+} from '../../helper/date.helper';
 
 describe('Non-Resident Quarterly Validation Tests', () => {
   const policy: Policy = new Policy(currentConfig);
 
   it('should validate NRQCV successfully', async () => {
     const permit = JSON.parse(JSON.stringify(validNrqcv));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
     const validationResult = await policy.validate(permit);
@@ -27,13 +35,18 @@ describe('Non-Resident Quarterly Validation Tests', () => {
 
   it('should fail validation for NRQCV with invalid vehicle subtype', async () => {
     const permit = JSON.parse(JSON.stringify(validNrqcv));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
     permit.permitData.vehicleDetails.vehicleSubType = '__INVALID';
@@ -44,11 +57,17 @@ describe('Non-Resident Quarterly Validation Tests', () => {
 
   it('should fail validation for NRQCV with start date not end of quarter', async () => {
     const permit = JSON.parse(JSON.stringify(validNrqcv));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
+
     permit.permitData.expiryDate = permit.permitData.startDate;
 
     const validationResult = await policy.validate(permit);
@@ -57,16 +76,20 @@ describe('Non-Resident Quarterly Validation Tests', () => {
 
   it('should fail validation for NRQCV with loadedGVW greater than 63,500', async () => {
     const permit = JSON.parse(JSON.stringify(validNrqcv));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
-    // Set loadedGVW to 63501
     permit.permitData.vehicleConfiguration.loadedGVW = 63501;
 
     const validationResult = await policy.validate(permit);
@@ -75,19 +98,21 @@ describe('Non-Resident Quarterly Validation Tests', () => {
 
   it('should fail validation for NRQCV with netWeight of a farm vehicle greater than 24,400', async () => {
     const permit = JSON.parse(JSON.stringify(validNrqcv));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
-    // Set loadedGVW to 24401
     permit.permitData.vehicleConfiguration.loadedGVW = 24401;
-
-    // Set conditionalLicensingFee to farm-vehicle
     permit.permitData.conditionalLicensingFee = 'farm-vehicle';
 
     const validationResult = await policy.validate(permit);
@@ -96,16 +121,20 @@ describe('Non-Resident Quarterly Validation Tests', () => {
 
   it('should fail validation for NRQCV with loadedGVW of zero', async () => {
     const permit = JSON.parse(JSON.stringify(validNrqcv));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
-    // Set loadedGVW to 0
     permit.permitData.vehicleConfiguration.loadedGVW = 0;
 
     const validationResult = await policy.validate(permit);
@@ -114,16 +143,20 @@ describe('Non-Resident Quarterly Validation Tests', () => {
 
   it('should fail validation for NRQCV with negative loadedGVW', async () => {
     const permit = JSON.parse(JSON.stringify(validNrqcv));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
-    // Set loadedGVW to -1000
     permit.permitData.vehicleConfiguration.loadedGVW = -1000;
 
     const validationResult = await policy.validate(permit);
@@ -132,16 +165,20 @@ describe('Non-Resident Quarterly Validation Tests', () => {
 
   it('should pass validation for NRQCV with loadedGVW exactly 63,500', async () => {
     const permit = JSON.parse(JSON.stringify(validNrqcv));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
-    // Set loadedGVW to 63500
     permit.permitData.vehicleConfiguration.loadedGVW = 63500;
 
     const validationResult = await policy.validate(permit);
@@ -150,16 +187,20 @@ describe('Non-Resident Quarterly Validation Tests', () => {
 
   it('should pass validation for NRQCV with loadedGVW 1 kg', async () => {
     const permit = JSON.parse(JSON.stringify(validNrqcv));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
-    // Set loadedGVW to 1
     permit.permitData.vehicleConfiguration.loadedGVW = 1;
 
     const validationResult = await policy.validate(permit);
@@ -168,16 +209,20 @@ describe('Non-Resident Quarterly Validation Tests', () => {
 
   it('should pass validation for NRQCV with conditional licensing fee none', async () => {
     const permit = JSON.parse(JSON.stringify(validNrqcv));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
-    // Set conditionalLicensingFee to none
     permit.permitData.conditionalLicensingFee = 'none';
 
     const validationResult = await policy.validate(permit);
@@ -186,16 +231,20 @@ describe('Non-Resident Quarterly Validation Tests', () => {
 
   it('should pass validation for NRQCV with conditional licensing fee x-plated', async () => {
     const permit = JSON.parse(JSON.stringify(validNrqcv));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
-    // Set conditionalLicensingFee to x-plated
     permit.permitData.conditionalLicensingFee = 'x-plated';
 
     const validationResult = await policy.validate(permit);
@@ -204,16 +253,20 @@ describe('Non-Resident Quarterly Validation Tests', () => {
 
   it('should pass validation for NRQCV with conditional licensing fee commercial-passenger', async () => {
     const permit = JSON.parse(JSON.stringify(validNrqcv));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
-    // Set conditionalLicensingFee to commercial-passenger
     permit.permitData.conditionalLicensingFee = 'commercial-passenger';
 
     const validationResult = await policy.validate(permit);
@@ -222,17 +275,22 @@ describe('Non-Resident Quarterly Validation Tests', () => {
 
   it('should pass validation for NRQCV with conditional licensing fee farm-vehicle', async () => {
     const permit = JSON.parse(JSON.stringify(validNrqcv));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
-    // Set conditionalLicensingFee to farm-vehicle
     permit.permitData.conditionalLicensingFee = 'farm-vehicle';
+
     // Farm vehicles require netWeight, not loadedGVW
     permit.permitData.vehicleConfiguration.netWeight = 1000;
 
@@ -242,16 +300,20 @@ describe('Non-Resident Quarterly Validation Tests', () => {
 
   it('should pass validation for NRQCV with conditional licensing fee farm-tractor', async () => {
     const permit = JSON.parse(JSON.stringify(validNrqcv));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
-    // Set conditionalLicensingFee to farm-tractor
     permit.permitData.conditionalLicensingFee = 'farm-tractor';
 
     const validationResult = await policy.validate(permit);
@@ -260,16 +322,20 @@ describe('Non-Resident Quarterly Validation Tests', () => {
 
   it('should pass validation for NRQCV with conditional licensing fee conditional', async () => {
     const permit = JSON.parse(JSON.stringify(validNrqcv));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
-    // Set conditionalLicensingFee to conditional
     permit.permitData.conditionalLicensingFee = 'conditional';
 
     const validationResult = await policy.validate(permit);
@@ -278,16 +344,20 @@ describe('Non-Resident Quarterly Validation Tests', () => {
 
   it('should fail validation for NRQCV with conditional licensing fee __invalid', async () => {
     const permit = JSON.parse(JSON.stringify(validNrqcv));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
-    // Set conditionalLicensingFee to __invalid
     permit.permitData.conditionalLicensingFee = '__invalid';
 
     const validationResult = await policy.validate(permit);
@@ -296,16 +366,20 @@ describe('Non-Resident Quarterly Validation Tests', () => {
 
   it('should fail validation for NRQCV with undefined conditional licensing fee', async () => {
     const permit = JSON.parse(JSON.stringify(validNrqcv));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
-    // deletee conditionalLicensingFee
     delete permit.permitData.conditionalLicensingFee;
 
     const validationResult = await policy.validate(permit);
@@ -314,175 +388,218 @@ describe('Non-Resident Quarterly Validation Tests', () => {
 
   it('should calculate NRQCV conditional cost correctly', async () => {
     const permit = JSON.parse(JSON.stringify(validNrqcv));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
-    // Set conditionalLicensingFee to conditional
+    
     permit.permitData.conditionalLicensingFee = 'conditional';
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.cost).not.toHaveLength(0);
+
     const initialValue: number = 0;
     const cost = validationResult.cost.reduce(
       (prev: any, curr: any) => prev + curr.cost,
       initialValue,
     );
+
     expect(cost).toBe(12);
   });
 
   it('should calculate NRQCV cv (none) vehicle cost correctly for 6000kg', async () => {
     const permit = JSON.parse(JSON.stringify(validNrqcv));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
-    // Set conditionalLicensingFee to none
+    
     permit.permitData.conditionalLicensingFee = 'none';
-    // Set loadedGVW to 6000
     permit.permitData.vehicleConfiguration.loadedGVW = 6000;
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.cost).not.toHaveLength(0);
+
     const initialValue: number = 0;
     const cost = validationResult.cost.reduce(
       (prev: any, curr: any) => prev + curr.cost,
       initialValue,
     );
+
     expect(cost).toBe(53);
   });
 
   it('should calculate NRQCV cv (none) vehicle cost correctly for 25000kg', async () => {
     const permit = JSON.parse(JSON.stringify(validNrqcv));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
-    // Set conditionalLicensingFee to none
+    
     permit.permitData.conditionalLicensingFee = 'none';
-    // Set loadedGVW to 25000
     permit.permitData.vehicleConfiguration.loadedGVW = 25000;
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.cost).not.toHaveLength(0);
+
     const initialValue: number = 0;
     const cost = validationResult.cost.reduce(
       (prev: any, curr: any) => prev + curr.cost,
       initialValue,
     );
+
     expect(cost).toBe(313);
   });
 
   it('should calculate NRQCV x-plated cost correctly', async () => {
     const permit = JSON.parse(JSON.stringify(validNrqcv));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
-    // Set conditionalLicensingFee to x-plated
+    
     permit.permitData.conditionalLicensingFee = 'x-plated';
-    // Set loadedGVW to 6000
     permit.permitData.vehicleConfiguration.loadedGVW = 6000;
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.cost).not.toHaveLength(0);
+
     const initialValue: number = 0;
     const cost = validationResult.cost.reduce(
       (prev: any, curr: any) => prev + curr.cost,
       initialValue,
     );
+
     expect(cost).toBe(28);
   });
 
   it('should calculate NRQCV commercial-passenger cost correctly', async () => {
     const permit = JSON.parse(JSON.stringify(validNrqcv));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
-    // Set conditionalLicensingFee to commercial-passenger
+    
     permit.permitData.conditionalLicensingFee = 'commercial-passenger';
-    // Set loadedGVW to 6250
     permit.permitData.vehicleConfiguration.loadedGVW = 6250;
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.cost).not.toHaveLength(0);
+
     const initialValue: number = 0;
     const cost = validationResult.cost.reduce(
       (prev: any, curr: any) => prev + curr.cost,
       initialValue,
     );
+
     expect(cost).toBe(55);
   });
 
   it('should calculate NRQCV farm tractor cost correctly', async () => {
     const permit = JSON.parse(JSON.stringify(validNrqcv));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
-    // Set conditionalLicensingFee to farm
+    
     permit.permitData.conditionalLicensingFee = 'farm-tractor';
-    // Set loadedGVW to 24400
     permit.permitData.vehicleConfiguration.loadedGVW = 24400;
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.cost).not.toHaveLength(0);
+
     const initialValue: number = 0;
     const cost = validationResult.cost.reduce(
       (prev: any, curr: any) => prev + curr.cost,
       initialValue,
     );
+
     expect(cost).toBe(33);
   });
 
   it('should calculate NRQCV farm vehicle cost correctly', async () => {
     const permit = JSON.parse(JSON.stringify(validNrqcv));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
-    // Set conditionalLicensingFee to farm
+    
     permit.permitData.conditionalLicensingFee = 'farm-vehicle';
-    // Set netWeight to 24400, deleting loadedGVW property
     delete permit.permitData.vehicleConfiguration.loadedGVW;
     permit.permitData.vehicleConfiguration.netWeight = 24400;
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.cost).not.toHaveLength(0);
+
     const initialValue: number = 0;
     const cost = validationResult.cost.reduce(
       (prev: any, curr: any) => prev + curr.cost,
       initialValue,
     );
+
     expect(cost).toBe(327);
   });
 });

--- a/src/_test/unit/nrscv-validation.spec.ts
+++ b/src/_test/unit/nrscv-validation.spec.ts
@@ -1,19 +1,28 @@
 import { Policy } from 'onroute-policy-engine';
+
 import currentConfig from '../policy-config/_current-config.json';
 import validNrscv from '../permit-app/valid-nrscv-30day.json';
-import dayjs from 'dayjs';
 import { PermitAppInfo } from '../../enum/permit-app-info';
+import {
+  convertToTimezone,
+  getUtcDatetime,
+  TIMEZONE_IDS,
+} from '../../helper/date.helper';
 
 describe('Non-Resident Single Trip Validation Tests', () => {
   const policy: Policy = new Policy(currentConfig);
 
   it('should validate NRSCV successfully', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
     // Note: we do not need to set the expiry date as well because
     // the validation only uses permitDuration, not expiryDate for this
     // permit type.
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -23,8 +32,12 @@ describe('Non-Resident Single Trip Validation Tests', () => {
 
   it('should fail validation for NRSCV with invalid vehicle subtype', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -36,12 +49,15 @@ describe('Non-Resident Single Trip Validation Tests', () => {
 
   it('should validate NRSCV successfully with 29 day duration', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set duration to 29
     permit.permitData.permitDuration = 29;
 
     const validationResult = await policy.validate(permit);
@@ -50,12 +66,15 @@ describe('Non-Resident Single Trip Validation Tests', () => {
 
   it('should validate NRSCV successfully with 30 day duration', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set duration to 30
     permit.permitData.permitDuration = 30;
 
     const validationResult = await policy.validate(permit);
@@ -64,12 +83,15 @@ describe('Non-Resident Single Trip Validation Tests', () => {
 
   it('should fail validation for NRSCV with 31 day duration', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set duration to 31
     permit.permitData.permitDuration = 31;
 
     const validationResult = await policy.validate(permit);
@@ -78,12 +100,15 @@ describe('Non-Resident Single Trip Validation Tests', () => {
 
   it('should fail validation for NRSCV with 0 day duration', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set duration to 0
     permit.permitData.permitDuration = 0;
 
     const validationResult = await policy.validate(permit);
@@ -92,12 +117,15 @@ describe('Non-Resident Single Trip Validation Tests', () => {
 
   it('should fail validation for NRSCV with loadedGVW greater than 63,500', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set loadedGVW to 63501
     permit.permitData.vehicleConfiguration.loadedGVW = 63501;
 
     const validationResult = await policy.validate(permit);
@@ -106,15 +134,16 @@ describe('Non-Resident Single Trip Validation Tests', () => {
 
   it('should fail validation for NRSCV with netWeight of a farm vehicle greater than 24,400', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set netWeight to 24401
     permit.permitData.vehicleConfiguration.netWeight = 24401;
-
-    // Set conditionalLicensingFee to farm
     permit.permitData.conditionalLicensingFee = 'farm-vehicle';
 
     const validationResult = await policy.validate(permit);
@@ -123,12 +152,15 @@ describe('Non-Resident Single Trip Validation Tests', () => {
 
   it('should fail validation for NRSCV with loadedGVW of zero', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set loadedGVW to 0
     permit.permitData.vehicleConfiguration.loadedGVW = 0;
 
     const validationResult = await policy.validate(permit);
@@ -137,12 +169,15 @@ describe('Non-Resident Single Trip Validation Tests', () => {
 
   it('should fail validation for NRSCV with negative loadedGVW', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set loadedGVW to -1000
     permit.permitData.vehicleConfiguration.loadedGVW = -1000;
 
     const validationResult = await policy.validate(permit);
@@ -151,12 +186,15 @@ describe('Non-Resident Single Trip Validation Tests', () => {
 
   it('should pass validation for NRSCV with loadedGVW exactly 63,500', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set loadedGVW to 63500
     permit.permitData.vehicleConfiguration.loadedGVW = 63500;
 
     const validationResult = await policy.validate(permit);
@@ -165,12 +203,15 @@ describe('Non-Resident Single Trip Validation Tests', () => {
 
   it('should pass validation for NRSCV with loadedGVW 1 kg', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set loadedGVW to 1
     permit.permitData.vehicleConfiguration.loadedGVW = 1;
 
     const validationResult = await policy.validate(permit);
@@ -179,12 +220,15 @@ describe('Non-Resident Single Trip Validation Tests', () => {
 
   it('should pass validation for NRSCV with conditional licensing fee none', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set conditionalLicensingFee to none
     permit.permitData.conditionalLicensingFee = 'none';
 
     const validationResult = await policy.validate(permit);
@@ -193,12 +237,15 @@ describe('Non-Resident Single Trip Validation Tests', () => {
 
   it('should pass validation for NRSCV with conditional licensing fee x-plated', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set conditionalLicensingFee to x-plated
     permit.permitData.conditionalLicensingFee = 'x-plated';
 
     const validationResult = await policy.validate(permit);
@@ -207,12 +254,15 @@ describe('Non-Resident Single Trip Validation Tests', () => {
 
   it('should pass validation for NRSCV with conditional licensing fee commercial-passenger', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set conditionalLicensingFee to commercial-passenger
     permit.permitData.conditionalLicensingFee = 'commercial-passenger';
 
     const validationResult = await policy.validate(permit);
@@ -221,14 +271,16 @@ describe('Non-Resident Single Trip Validation Tests', () => {
 
   it('should pass validation for NRSCV with conditional licensing fee farm-vehicle', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set conditionalLicensingFee to farm
     permit.permitData.conditionalLicensingFee = 'farm-vehicle';
-    // Farm vehicles require netWeight, not loadedGVW
     permit.permitData.vehicleConfiguration.netWeight = 10000;
 
     const validationResult = await policy.validate(permit);
@@ -237,12 +289,15 @@ describe('Non-Resident Single Trip Validation Tests', () => {
 
   it('should pass validation for NRSCV with conditional licensing fee farm-tractor', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set conditionalLicensingFee to farm
     permit.permitData.conditionalLicensingFee = 'farm-tractor';
 
     const validationResult = await policy.validate(permit);
@@ -251,12 +306,15 @@ describe('Non-Resident Single Trip Validation Tests', () => {
 
   it('should pass validation for NRSCV with conditional licensing fee conditional', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set conditionalLicensingFee to conditional
     permit.permitData.conditionalLicensingFee = 'conditional';
 
     const validationResult = await policy.validate(permit);
@@ -265,12 +323,15 @@ describe('Non-Resident Single Trip Validation Tests', () => {
 
   it('should fail validation for NRSCV with conditional licensing fee __invalid', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // Set conditionalLicensingFee to __invalid
     permit.permitData.conditionalLicensingFee = '__invalid';
 
     const validationResult = await policy.validate(permit);
@@ -279,12 +340,15 @@ describe('Non-Resident Single Trip Validation Tests', () => {
 
   it('should fail validation for NRSCV with undefined conditional licensing fee', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // deletee conditionalLicensingFee
     delete permit.permitData.conditionalLicensingFee;
 
     const validationResult = await policy.validate(permit);
@@ -293,147 +357,183 @@ describe('Non-Resident Single Trip Validation Tests', () => {
 
   it('should calculate NRSCV conditional cost correctly', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    // Set conditionalLicensingFee to conditional
+
     permit.permitData.conditionalLicensingFee = 'conditional';
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.cost).not.toHaveLength(0);
+
     const initialValue: number = 0;
     const cost = validationResult.cost.reduce(
       (prev: any, curr: any) => prev + curr.cost,
       initialValue,
     );
+
     expect(cost).toBe(12);
   });
 
   it('should calculate NRSCV cv (none) vehicle cost correctly for 6000kg', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    // Set conditionalLicensingFee to none
+
     permit.permitData.conditionalLicensingFee = 'none';
-    // Set loadedGVW to 6000
     permit.permitData.vehicleConfiguration.loadedGVW = 6000;
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.cost).not.toHaveLength(0);
+
     const initialValue: number = 0;
     const cost = validationResult.cost.reduce(
       (prev: any, curr: any) => prev + curr.cost,
       initialValue,
     );
+
     expect(cost).toBe(18);
   });
 
   it('should calculate NRSCV cv (none) vehicle cost correctly for 25000kg', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    // Set conditionalLicensingFee to none
+
     permit.permitData.conditionalLicensingFee = 'none';
-    // Set loadedGVW to 25000
     permit.permitData.vehicleConfiguration.loadedGVW = 25000;
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.cost).not.toHaveLength(0);
+
     const initialValue: number = 0;
     const cost = validationResult.cost.reduce(
       (prev: any, curr: any) => prev + curr.cost,
       initialValue,
     );
+
     expect(cost).toBe(104);
   });
 
   it('should calculate NRSCV x-plated cost correctly', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    // Set conditionalLicensingFee to x-plated
+
     permit.permitData.conditionalLicensingFee = 'x-plated';
-    // Set loadedGVW to 6000
     permit.permitData.vehicleConfiguration.loadedGVW = 6000;
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.cost).not.toHaveLength(0);
+
     const initialValue: number = 0;
     const cost = validationResult.cost.reduce(
       (prev: any, curr: any) => prev + curr.cost,
       initialValue,
     );
+
     expect(cost).toBe(9);
   });
 
   it('should calculate NRSCV commercial-passenger cost correctly', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    // Set conditionalLicensingFee to commercial-passenger
+
     permit.permitData.conditionalLicensingFee = 'commercial-passenger';
-    // Set loadedGVW to 6250
     permit.permitData.vehicleConfiguration.loadedGVW = 6250;
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.cost).not.toHaveLength(0);
+
     const initialValue: number = 0;
     const cost = validationResult.cost.reduce(
       (prev: any, curr: any) => prev + curr.cost,
       initialValue,
     );
+
     expect(cost).toBe(18);
   });
 
   it('should calculate NRSCV farm vehicle cost correctly', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    // Set conditionalLicensingFee to farm
+
     permit.permitData.conditionalLicensingFee = 'farm-vehicle';
-    // Set netWeight to 24400, deleting loadedGVW property
     delete permit.permitData.vehicleConfiguration.loadedGVW;
     permit.permitData.vehicleConfiguration.netWeight = 24400;
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.cost).not.toHaveLength(0);
+
     const initialValue: number = 0;
     const cost = validationResult.cost.reduce(
       (prev: any, curr: any) => prev + curr.cost,
       initialValue,
     );
+
     expect(cost).toBe(109);
   });
 
   it('should calculate NRSCV farm tractor cost correctly', async () => {
     const permit = JSON.parse(JSON.stringify(validNrscv));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    // Set conditionalLicensingFee to farm
+
     permit.permitData.conditionalLicensingFee = 'farm-tractor';
-    // Set loadedGVW to 24400
     permit.permitData.vehicleConfiguration.loadedGVW = 24400;
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.cost).not.toHaveLength(0);
+
     const initialValue: number = 0;
     const cost = validationResult.cost.reduce(
       (prev: any, curr: any) => prev + curr.cost,
       initialValue,
     );
+    
     expect(cost).toBe(33);
   });
 });

--- a/src/_test/unit/qrfr-validation.spec.ts
+++ b/src/_test/unit/qrfr-validation.spec.ts
@@ -1,24 +1,32 @@
 import { Policy } from 'onroute-policy-engine';
+
 import currentConfig from '../policy-config/_current-config.json';
 import validQrfr from '../permit-app/valid-qrfr.json';
-import dayjs from 'dayjs';
-import quarterOfYear from 'dayjs/plugin/quarterOfYear';
 import { PermitAppInfo } from '../../enum/permit-app-info';
-
-dayjs.extend(quarterOfYear);
+import {
+  convertToTimezone,
+  getEndOfQuarter,
+  getUtcDatetime,
+  TIMEZONE_IDS,
+} from '../../helper/date.helper';
 
 describe('Quarterly ICBC Basic Insurance (FR) Validation Tests', () => {
   const policy: Policy = new Policy(currentConfig);
 
   it('should validate QRFR successfully', async () => {
     const permit = JSON.parse(JSON.stringify(validQrfr));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
     const validationResult = await policy.validate(permit);
@@ -27,11 +35,17 @@ describe('Quarterly ICBC Basic Insurance (FR) Validation Tests', () => {
 
   it('should fail validation for QRFR with start date not end of quarter', async () => {
     const permit = JSON.parse(JSON.stringify(validQrfr));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
+
     permit.permitData.expiryDate = permit.permitData.startDate;
 
     const validationResult = await policy.validate(permit);
@@ -40,13 +54,18 @@ describe('Quarterly ICBC Basic Insurance (FR) Validation Tests', () => {
 
   it('should fail validation for QRFR with invalid vehicle subtype', async () => {
     const permit = JSON.parse(JSON.stringify(validQrfr));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
     permit.permitData.vehicleDetails.vehicleSubType = '__INVALID';
@@ -57,13 +76,18 @@ describe('Quarterly ICBC Basic Insurance (FR) Validation Tests', () => {
 
   it('should fail validation for QRFR with licensed GVW greater than 63,500', async () => {
     const permit = JSON.parse(JSON.stringify(validQrfr));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
     // Set licensedGVW to 63501
@@ -75,13 +99,18 @@ describe('Quarterly ICBC Basic Insurance (FR) Validation Tests', () => {
 
   it('should fail validation for QRFR with licensed GVW of zero', async () => {
     const permit = JSON.parse(JSON.stringify(validQrfr));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
     // Set licensedGVW to 0
@@ -93,13 +122,18 @@ describe('Quarterly ICBC Basic Insurance (FR) Validation Tests', () => {
 
   it('should fail validation for QRFR with negative licensed GVW', async () => {
     const permit = JSON.parse(JSON.stringify(validQrfr));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
     // Set licensedGVW to -1000
@@ -111,13 +145,18 @@ describe('Quarterly ICBC Basic Insurance (FR) Validation Tests', () => {
 
   it('should pass validation for QRFR with licensed GVW exactly 63,500', async () => {
     const permit = JSON.parse(JSON.stringify(validQrfr));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
     // Set licensedGVW to 63500
@@ -129,13 +168,18 @@ describe('Quarterly ICBC Basic Insurance (FR) Validation Tests', () => {
 
   it('should pass validation for QRFR with licensed GVW 1 kg', async () => {
     const permit = JSON.parse(JSON.stringify(validQrfr));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
     // Set licensedGVW to 1
@@ -147,13 +191,18 @@ describe('Quarterly ICBC Basic Insurance (FR) Validation Tests', () => {
 
   it('should pass validation for QRFR with third party liability GENERAL_GOODS', async () => {
     const permit = JSON.parse(JSON.stringify(validQrfr));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
     // Set thirdPartyLiability to GENERAL_GOODS
@@ -165,13 +214,18 @@ describe('Quarterly ICBC Basic Insurance (FR) Validation Tests', () => {
 
   it('should pass validation for QRFR with third party liability DANGEROUS_GOODS', async () => {
     const permit = JSON.parse(JSON.stringify(validQrfr));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
     // Set thirdPartyLiability to DANGEROUS_GOODS
@@ -183,13 +237,18 @@ describe('Quarterly ICBC Basic Insurance (FR) Validation Tests', () => {
 
   it('should fail validation for QRFR with third party liability dangerous_goods (exact match required)', async () => {
     const permit = JSON.parse(JSON.stringify(validQrfr));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
     // Set thirdPartyLiability to dangerous_goods
@@ -201,16 +260,20 @@ describe('Quarterly ICBC Basic Insurance (FR) Validation Tests', () => {
 
   it('should fail validation for QRFR with undefined third party liability', async () => {
     const permit = JSON.parse(JSON.stringify(validQrfr));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
 
-    // deletee thirdPartyLiability
     delete permit.permitData.thirdPartyLiability;
 
     const validationResult = await policy.validate(permit);
@@ -219,47 +282,63 @@ describe('Quarterly ICBC Basic Insurance (FR) Validation Tests', () => {
 
   it('should calculate QRFR general goods cost correctly', async () => {
     const permit = JSON.parse(JSON.stringify(validQrfr));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
+    
     // Set thirdPartyLiability to GENERAL_GOODS
     permit.permitData.thirdPartyLiability = 'GENERAL_GOODS';
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.cost).not.toHaveLength(0);
+
     const initialValue: number = 0;
     const cost = validationResult.cost.reduce(
       (prev: any, curr: any) => prev + curr.cost,
       initialValue,
     );
+
     expect(cost).toBe(843);
   });
 
   it('should calculate QRFR dangerous goods cost correctly', async () => {
     const permit = JSON.parse(JSON.stringify(validQrfr));
+
     // Set startDate to today, end date to the end of the quarter
-    const dateFrom = dayjs();
+    const dateFrom = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = dateFrom.format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    permit.permitData.expiryDate = dateFrom
-      .endOf('quarter')
+
+    permit.permitData.expiryDate = getEndOfQuarter(dateFrom)
       .format(PermitAppInfo.PermitDateFormat.toString());
+    
     // Set thirdPartyLiability to DANGEROUS_GOODS
     permit.permitData.thirdPartyLiability = 'DANGEROUS_GOODS';
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.cost).not.toHaveLength(0);
+
     const initialValue: number = 0;
     const cost = validationResult.cost.reduce(
       (prev: any, curr: any) => prev + curr.cost,
       initialValue,
     );
+
     expect(cost).toBe(899);
   });
 });

--- a/src/_test/unit/stfr-validation.spec.ts
+++ b/src/_test/unit/stfr-validation.spec.ts
@@ -1,19 +1,24 @@
 import { Policy } from 'onroute-policy-engine';
+
 import currentConfig from '../policy-config/_current-config.json';
 import validStfr30Day from '../permit-app/valid-stfr-30day.json';
-import dayjs from 'dayjs';
 import { PermitAppInfo } from '../../enum/permit-app-info';
+import { convertToTimezone, getUtcDatetime, TIMEZONE_IDS } from '../../helper/date.helper';
 
 describe('Single Trip ICBC (FR) Validator', () => {
   const policy: Policy = new Policy(currentConfig);
 
   it('should validate STFR successfully', async () => {
     const permit = JSON.parse(JSON.stringify(validStfr30Day));
+
     // Set startDate to today
     // Note: we do not need to set the expiry date as well because
     // the validation only uses permitDuration, not expiryDate for this
     // permit type.
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -23,8 +28,12 @@ describe('Single Trip ICBC (FR) Validator', () => {
 
   it('should fail validation for STFR with invalid vehicle subtype', async () => {
     const permit = JSON.parse(JSON.stringify(validStfr30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -36,8 +45,12 @@ describe('Single Trip ICBC (FR) Validator', () => {
 
   it('should validate STFR successfully with 29 day duration', async () => {
     const permit = JSON.parse(JSON.stringify(validStfr30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -50,8 +63,12 @@ describe('Single Trip ICBC (FR) Validator', () => {
 
   it('should validate STFR successfully with 30 day duration', async () => {
     const permit = JSON.parse(JSON.stringify(validStfr30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -64,8 +81,12 @@ describe('Single Trip ICBC (FR) Validator', () => {
 
   it('should fail validation for STFR with 31 day duration', async () => {
     const permit = JSON.parse(JSON.stringify(validStfr30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -78,8 +99,12 @@ describe('Single Trip ICBC (FR) Validator', () => {
 
   it('should fail validation for STFR with 0 day duration', async () => {
     const permit = JSON.parse(JSON.stringify(validStfr30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -92,8 +117,12 @@ describe('Single Trip ICBC (FR) Validator', () => {
 
   it('should fail validation for STFR with licensed GVW greater than 63,500', async () => {
     const permit = JSON.parse(JSON.stringify(validStfr30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -106,8 +135,12 @@ describe('Single Trip ICBC (FR) Validator', () => {
 
   it('should fail validation for STFR with licensed GVW of zero', async () => {
     const permit = JSON.parse(JSON.stringify(validStfr30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -120,8 +153,12 @@ describe('Single Trip ICBC (FR) Validator', () => {
 
   it('should fail validation for STFR with negative licensed GVW', async () => {
     const permit = JSON.parse(JSON.stringify(validStfr30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -134,8 +171,12 @@ describe('Single Trip ICBC (FR) Validator', () => {
 
   it('should pass validation for STFR with licensed GVW exactly 63,500', async () => {
     const permit = JSON.parse(JSON.stringify(validStfr30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -148,8 +189,12 @@ describe('Single Trip ICBC (FR) Validator', () => {
 
   it('should pass validation for STFR with licensed GVW 1 kg', async () => {
     const permit = JSON.parse(JSON.stringify(validStfr30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -162,8 +207,12 @@ describe('Single Trip ICBC (FR) Validator', () => {
 
   it('should pass validation for STFR with third party liability GENERAL_GOODS', async () => {
     const permit = JSON.parse(JSON.stringify(validStfr30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -176,8 +225,12 @@ describe('Single Trip ICBC (FR) Validator', () => {
 
   it('should pass validation for STFR with third party liability DANGEROUS_GOODS', async () => {
     const permit = JSON.parse(JSON.stringify(validStfr30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -190,8 +243,12 @@ describe('Single Trip ICBC (FR) Validator', () => {
 
   it('should fail validation for STFR with third party liability dangerous_goods (exact match required)', async () => {
     const permit = JSON.parse(JSON.stringify(validStfr30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -204,12 +261,15 @@ describe('Single Trip ICBC (FR) Validator', () => {
 
   it('should fail validation for STFR with undefined third party liability', async () => {
     const permit = JSON.parse(JSON.stringify(validStfr30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
-    // deletee thirdPartyLiability
     delete permit.permitData.thirdPartyLiability;
 
     const validationResult = await policy.validate(permit);
@@ -218,39 +278,53 @@ describe('Single Trip ICBC (FR) Validator', () => {
 
   it('should calculate STFR general goods cost correctly', async () => {
     const permit = JSON.parse(JSON.stringify(validStfr30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
+
     // Set thirdPartyLiability to GENERAL_GOODS
     permit.permitData.thirdPartyLiability = 'GENERAL_GOODS';
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.cost).not.toHaveLength(0);
+
     const initialValue: number = 0;
     const cost = validationResult.cost.reduce(
       (prev: any, curr: any) => prev + curr.cost,
       initialValue,
     );
+
     expect(cost).toBe(84);
   });
 
   it('should calculate STFR dangerous goods cost correctly', async () => {
     const permit = JSON.parse(JSON.stringify(validStfr30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
+
     // Set thirdPartyLiability to DANGEROUS_GOODS
     permit.permitData.thirdPartyLiability = 'DANGEROUS_GOODS';
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.cost).not.toHaveLength(0);
+
     const initialValue: number = 0;
     const cost = validationResult.cost.reduce(
       (prev: any, curr: any) => prev + curr.cost,
       initialValue,
     );
+    
     expect(cost).toBe(89);
   });
 });

--- a/src/_test/unit/stgvwi.spec.ts
+++ b/src/_test/unit/stgvwi.spec.ts
@@ -1,8 +1,13 @@
 import { Policy } from 'onroute-policy-engine';
+
 import currentConfig from '../policy-config/_current-config.json';
 import validSTGVWI from '../permit-app/valid-stgvwi.json';
-import dayjs from 'dayjs';
 import { PermitAppInfo } from '../../enum/permit-app-info';
+import {
+  convertToTimezone,
+  getUtcDatetime,
+  TIMEZONE_IDS,
+} from '../../helper/date.helper';
 
 describe('Single Trip GVW Increase (STGVWI) Validator', () => {
   const policy: Policy = new Policy(currentConfig);
@@ -10,89 +15,104 @@ describe('Single Trip GVW Increase (STGVWI) Validator', () => {
   it('should validate STGVWI successfully', async () => {
     const permit = JSON.parse(JSON.stringify(validSTGVWI));
 
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
     const validationResult = await policy.validate(permit);
-
     expect(validationResult.violations).toHaveLength(0);
   });
 
   it('should validate STGVWI successfully with 6 day duration', async () => {
     const permit = JSON.parse(JSON.stringify(validSTGVWI));
 
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
     permit.permitData.permitDuration = 6;
 
     const validationResult = await policy.validate(permit);
-
     expect(validationResult.violations).toHaveLength(0);
   });
 
   it('should validate STGVWI successfully with 7 day duration', async () => {
     const permit = JSON.parse(JSON.stringify(validSTGVWI));
 
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
     permit.permitData.permitDuration = 7;
 
     const validationResult = await policy.validate(permit);
-
     expect(validationResult.violations).toHaveLength(0);
   });
 
   it('should fail validation for STGVWI with 8 day duration', async () => {
     const permit = JSON.parse(JSON.stringify(validSTGVWI));
 
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
     permit.permitData.permitDuration = 8;
 
     const validationResult = await policy.validate(permit);
-
     expect(validationResult.violations).toHaveLength(1);
   });
 
   it('should fail validation for STGVWI with 0 day duration', async () => {
     const permit = JSON.parse(JSON.stringify(validSTGVWI));
 
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
     permit.permitData.permitDuration = 0;
 
     const validationResult = await policy.validate(permit);
-
     expect(validationResult.violations).toHaveLength(1);
   });
 
   it('should fail validation when Actual GVW is not provided', async () => {
     const permit = JSON.parse(JSON.stringify(validSTGVWI));
 
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
     permit.permitData.vehicleConfiguration.actualGVW = null;
 
     const validationResult = await policy.validate(permit);
-
     expect(validationResult.violations).toHaveLength(1);
   });
 
   it('should fail validation when Actual GVW is equal to Licensed GVW', async () => {
     const permit = JSON.parse(JSON.stringify(validSTGVWI));
 
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -100,14 +120,16 @@ describe('Single Trip GVW Increase (STGVWI) Validator', () => {
       permit.permitData.vehicleDetails.licensedGVW;
 
     const validationResult = await policy.validate(permit);
-
     expect(validationResult.violations).toHaveLength(1);
   });
 
   it('should fail validation when Actual GVW is less than Licensed GVW', async () => {
     const permit = JSON.parse(JSON.stringify(validSTGVWI));
 
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -115,14 +137,16 @@ describe('Single Trip GVW Increase (STGVWI) Validator', () => {
       permit.permitData.vehicleDetails.licensedGVW - 500;
 
     const validationResult = await policy.validate(permit);
-
     expect(validationResult.violations).toHaveLength(1);
   });
 
   it('should validate when Actual GVW is greater than Licensed GVW', async () => {
     const permit = JSON.parse(JSON.stringify(validSTGVWI));
 
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -130,14 +154,16 @@ describe('Single Trip GVW Increase (STGVWI) Validator', () => {
       permit.permitData.vehicleDetails.licensedGVW + 1;
 
     const validationResult = await policy.validate(permit);
-
     expect(validationResult.violations).toHaveLength(0);
   });
 
   it('should validate STGVWI with Actual GVW exactly 63,500kg', async () => {
     const permit = JSON.parse(JSON.stringify(validSTGVWI));
 
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -145,14 +171,16 @@ describe('Single Trip GVW Increase (STGVWI) Validator', () => {
     permit.permitData.vehicleConfiguration.actualGVW = 63500;
 
     const validationResult = await policy.validate(permit);
-
     expect(validationResult.violations).toHaveLength(0);
   });
 
   it('should fail validation when Actual GVW exceeds 63,500kg', async () => {
     const permit = JSON.parse(JSON.stringify(validSTGVWI));
 
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -160,7 +188,6 @@ describe('Single Trip GVW Increase (STGVWI) Validator', () => {
     permit.permitData.vehicleConfiguration.actualGVW = 63501;
 
     const validationResult = await policy.validate(permit);
-
     expect(validationResult.violations).toHaveLength(1);
   });
 });

--- a/src/_test/unit/stos-validation.spec.ts
+++ b/src/_test/unit/stos-validation.spec.ts
@@ -1,10 +1,15 @@
 import { Policy } from 'onroute-policy-engine';
+
 import currentConfig from '../policy-config/_current-config.json';
 import testStos from '../permit-app/test-stos.json';
 import lcvStos from '../permit-app/valid-stos-lcv.json';
 import specialAuth from '../policy-config/special-auth-lcv.sample.json';
-import dayjs from 'dayjs';
 import { PermitAppInfo } from '../../enum/permit-app-info';
+import {
+  convertToTimezone,
+  getUtcDatetime,
+  TIMEZONE_IDS,
+} from '../../helper/date.helper';
 
 describe('Single Trip Oversize Policy Configuration Validator', () => {
   const policy: Policy = new Policy(currentConfig);
@@ -12,8 +17,12 @@ describe('Single Trip Oversize Policy Configuration Validator', () => {
 
   it('should validate STOS successfully', async () => {
     const permit = JSON.parse(JSON.stringify(testStos));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -23,8 +32,12 @@ describe('Single Trip Oversize Policy Configuration Validator', () => {
 
   it('should validate LCV STOS successfully with LCV auth', async () => {
     const permit = JSON.parse(JSON.stringify(lcvStos));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -34,8 +47,12 @@ describe('Single Trip Oversize Policy Configuration Validator', () => {
 
   it('should fail to validate LCV STOS successfully without LCV auth', async () => {
     const permit = JSON.parse(JSON.stringify(lcvStos));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -45,8 +62,12 @@ describe('Single Trip Oversize Policy Configuration Validator', () => {
 
   it('should validate STOS successfully with 6 day duration', async () => {
     const permit = JSON.parse(JSON.stringify(testStos));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -59,8 +80,12 @@ describe('Single Trip Oversize Policy Configuration Validator', () => {
 
   it('should validate STOS successfully with 7 day duration', async () => {
     const permit = JSON.parse(JSON.stringify(testStos));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -73,8 +98,12 @@ describe('Single Trip Oversize Policy Configuration Validator', () => {
 
   it('should fail validation for STOS with 8 day duration', async () => {
     const permit = JSON.parse(JSON.stringify(testStos));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -87,8 +116,12 @@ describe('Single Trip Oversize Policy Configuration Validator', () => {
 
   it('should fail validation for STOS with 0 day duration', async () => {
     const permit = JSON.parse(JSON.stringify(testStos));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -101,10 +134,15 @@ describe('Single Trip Oversize Policy Configuration Validator', () => {
 
   it('should pass validation for STOS with multiple boosters', async () => {
     const permit = JSON.parse(JSON.stringify(testStos));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
+
     // Add two boosters to the configuration list
     // Note that this configuration allows boosters.
     permit.permitData.vehicleConfiguration.trailers.push({
@@ -120,10 +158,15 @@ describe('Single Trip Oversize Policy Configuration Validator', () => {
 
   it('should pass validation for STOS with multiple jeeps', async () => {
     const permit = JSON.parse(JSON.stringify(testStos));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
+
     // Add two jeeps to the configuration list
     // Note that this configuration allows jeeps.
     permit.permitData.vehicleConfiguration.trailers.splice(
@@ -143,10 +186,15 @@ describe('Single Trip Oversize Policy Configuration Validator', () => {
 
   it('should fail validation for STOS with jeep after the trailer', async () => {
     const permit = JSON.parse(JSON.stringify(testStos));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
+
     // Add jeep to the end of the configuration.
     // Note that this configuration allows jeeps.
     permit.permitData.vehicleConfiguration.trailers.push({
@@ -159,10 +207,15 @@ describe('Single Trip Oversize Policy Configuration Validator', () => {
 
   it('should fail validation for STOS with invalid configuration', async () => {
     const permit = JSON.parse(JSON.stringify(testStos));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
+
     // Add an invalid trailer to the configuration list
     permit.permitData.vehicleConfiguration.trailers.push({
       vehicleSubType: '_INVALID',

--- a/src/_test/unit/stow-validation.spec.ts
+++ b/src/_test/unit/stow-validation.spec.ts
@@ -1,9 +1,14 @@
-import { Policy } from '../../policy-engine';
+import { Policy } from 'onroute-policy-engine';
+
 import currentConfig from '../policy-config/_current-config.json';
 import testStow from '../permit-app/test-stow.json';
-import dayjs from 'dayjs';
 import { PermitAppInfo } from '../../enum/permit-app-info';
 import { PolicyCheckId, PolicyCheckResultType } from '../../enum/policy-check';
+import {
+  convertToTimezone,
+  getUtcDatetime,
+  TIMEZONE_IDS,
+} from '../../helper/date.helper';
 
 const reportedTrailerCrashInput = {
   currentFormData: {
@@ -142,9 +147,14 @@ describe('Single Trip Overweight Policy Configuration Validator', () => {
 
   const getDatedPermit = () => {
     const permit = JSON.parse(JSON.stringify(testStow));
-    permit.permitData.startDate = dayjs().format(
+
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
+
     permit.permitData.vehicleConfiguration.axleConfiguration[0].axleUnitWeight = 6000;
     return permit;
   };

--- a/src/_test/unit/stwse-validation.spec.ts
+++ b/src/_test/unit/stwse-validation.spec.ts
@@ -1,9 +1,13 @@
 import { Policy } from 'onroute-policy-engine';
-import dayjs from 'dayjs';
 
 import { PermitAppInfo } from '../../enum/permit-app-info';
 import currentConfig from '../policy-config/_current-config.json';
 import validSTWSE from '../permit-app/valid-stwse.json';
+import {
+  convertToTimezone,
+  getUtcDatetime,
+  TIMEZONE_IDS,
+} from '../../helper/date.helper';
 
 describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () => {
   const policy: Policy = new Policy(currentConfig);
@@ -11,7 +15,11 @@ describe('Empty - Single Trip Over Length 27.5m (STWSE) Validation Tests', () =>
   const getPermit = () => {
     const permit = JSON.parse(JSON.stringify(validSTWSE));
 
-    const today = dayjs();
+    const today = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    );
+
     permit.permitData.startDate = today
       .format(PermitAppInfo.PermitDateFormat);
 

--- a/src/_test/unit/validation.spec.ts
+++ b/src/_test/unit/validation.spec.ts
@@ -1,4 +1,5 @@
 import { Policy } from 'onroute-policy-engine';
+
 import trosOnly from '../policy-config/tros-only.sample.json';
 import trosNoAllowedVehicles from '../policy-config/tros-no-allowed-vehicles.sample.json';
 import currentConfig from '../policy-config/_current-config.json';
@@ -7,9 +8,9 @@ import validTros30Day from '../permit-app/valid-tros-30day.json';
 import validTrow120Day from '../permit-app/valid-trow-120day.json';
 import allEventTypes from '../policy-config/all-event-types.sample.json';
 import specialAuth from '../policy-config/special-auth-lcv.sample.json';
-import dayjs from 'dayjs';
 import { PermitAppInfo } from '../../enum/permit-app-info';
 import { ValidationResultCode } from '../../enum/validation-result-code';
+import { convertToTimezone, getUtcDatetime, TIMEZONE_IDS } from '../../helper/date.helper';
 
 describe('Permit Engine Constructor', () => {
   it('should construct without error with special authorizations', () => {
@@ -44,8 +45,12 @@ describe('Policy Engine Validator', () => {
 
   it('should validate TROS successfully', async () => {
     const permit = JSON.parse(JSON.stringify(validTros30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -55,10 +60,12 @@ describe('Policy Engine Validator', () => {
 
   it('should raise violation for start date in the past', async () => {
     const permit = JSON.parse(JSON.stringify(validTros30Day));
+
     // Set startDate to yesterday
-    permit.permitData.startDate = dayjs()
-      .subtract(1, 'day')
-      .format(PermitAppInfo.PermitDateFormat.toString());
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).subtract(1, 'day').format(PermitAppInfo.PermitDateFormat.toString());
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.violations).toHaveLength(1);
@@ -66,10 +73,12 @@ describe('Policy Engine Validator', () => {
 
   it('should raise violation for start date more than 14 days in future', async () => {
     const permit = JSON.parse(JSON.stringify(validTros30Day));
+
     // Set startDate to more than 14 days in the future
-    permit.permitData.startDate = dayjs()
-      .add(15, 'day')
-      .format(PermitAppInfo.PermitDateFormat.toString());
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).add(15, 'day').format(PermitAppInfo.PermitDateFormat.toString());
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.violations).toHaveLength(1);
@@ -77,10 +86,12 @@ describe('Policy Engine Validator', () => {
 
   it('should validate correctly for start date exactly 14 days in future', async () => {
     const permit = JSON.parse(JSON.stringify(validTros30Day));
+
     // Set startDate to yesterday
-    permit.permitData.startDate = dayjs()
-      .add(14, 'day')
-      .format(PermitAppInfo.PermitDateFormat.toString());
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).add(14, 'day').format(PermitAppInfo.PermitDateFormat.toString());
 
     const validationResult = await policy.validate(permit);
     expect(validationResult.violations).toHaveLength(0);
@@ -88,10 +99,15 @@ describe('Policy Engine Validator', () => {
 
   it('should raise violation for invalid permit type', async () => {
     const permit = JSON.parse(JSON.stringify(validTros30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
+
     permit.permitType = '__INVALID';
 
     const validationResult = await policy.validate(permit);
@@ -100,10 +116,15 @@ describe('Policy Engine Validator', () => {
 
   it('should raise violation for invalid vehicle type', async () => {
     const permit = JSON.parse(JSON.stringify(validTros30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
+
     // Set an invalid vehicle type
     permit.permitData.vehicleDetails.vehicleSubType = '__INVALID';
 
@@ -113,11 +134,16 @@ describe('Policy Engine Validator', () => {
 
   it('should raise violation for TROS lcv with no special auth', async () => {
     const permit = JSON.parse(JSON.stringify(validTros30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    // Set an lcv vehicle type
+
+    // Set an LCV vehicle type
     permit.permitData.vehicleDetails.vehicleSubType = 'LCVRMDB';
 
     const validationResult = await policy.validate(permit);
@@ -126,11 +152,16 @@ describe('Policy Engine Validator', () => {
 
   it('should validate lcv for TROS with special auth', async () => {
     const permit = JSON.parse(JSON.stringify(validTros30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    // Set an lcv vehicle type
+
+    // Set an LCV vehicle type
     permit.permitData.vehicleDetails.vehicleSubType = 'LCVRMDB';
 
     const validationResult = await lcvPolicy.validate(permit);
@@ -139,11 +170,16 @@ describe('Policy Engine Validator', () => {
 
   it('should validate lcv using set method instead of constructor', async () => {
     const permit = JSON.parse(JSON.stringify(validTros30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
-    // Set an lcv vehicle type
+
+    // Set an LCV vehicle type
     permit.permitData.vehicleDetails.vehicleSubType = 'LCVRMDB';
 
     const validationResult = await policy.validate(permit);
@@ -170,10 +206,15 @@ describe('Policy Engine Validator', () => {
 
   it('should return the correct validation code', async () => {
     const permit = JSON.parse(JSON.stringify(validTros30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
+
     // Set an invalid companyName
     permit.permitData.companyName = '';
 
@@ -186,10 +227,15 @@ describe('Policy Engine Validator', () => {
 
   it('should return the correct field reference', async () => {
     const permit = JSON.parse(JSON.stringify(validTros30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
+
     // Set an invalid companyName
     permit.permitData.companyName = '';
 
@@ -206,8 +252,12 @@ describe('Master Policy Configuration Validator', () => {
 
   it('should validate TROS successfully', async () => {
     const permit = JSON.parse(JSON.stringify(validTros30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -217,8 +267,12 @@ describe('Master Policy Configuration Validator', () => {
 
   it('should validate TROW successfully', async () => {
     const permit = JSON.parse(JSON.stringify(validTrow120Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -232,8 +286,12 @@ describe('Policy Configuration Missing Elements', () => {
 
   it('should not fail when a validation has no params', async () => {
     const permit = JSON.parse(JSON.stringify(validTros30Day));
+
     // Set startDate to today
-    permit.permitData.startDate = dayjs().format(
+    permit.permitData.startDate = convertToTimezone(
+      getUtcDatetime(),
+      TIMEZONE_IDS.PACIFIC,
+    ).format(
       PermitAppInfo.PermitDateFormat.toString(),
     );
 
@@ -251,11 +309,13 @@ describe('Permit Engine Validation Results Aggregator', () => {
     const permit = JSON.parse(JSON.stringify(validTros30Day));
 
     const validationResult = await policy.validate(permit);
+    
     // Violation 1: expected structure
     // Violation 2: unknown event type (defaults to violation)
     expect(validationResult.violations).toHaveLength(2);
     expect(validationResult.requirements).toHaveLength(1);
     expect(validationResult.warnings).toHaveLength(1);
+
     // Information 1: expected structure
     // Information 2: params object, but no message property
     // Information 3: no params object in the event

--- a/src/helper/date.helper.spec.ts
+++ b/src/helper/date.helper.spec.ts
@@ -1,0 +1,27 @@
+import { convertToTimezone, TIMEZONE_IDS, getUtcDatetime } from "./date.helper";
+
+describe('Date Helper Tests', () => {
+  it('should have correct local datetime components when converting datetime string', () => {
+    const localDtStr = '2026-08-10';
+    const localTzId = TIMEZONE_IDS.PACIFIC;
+    const localDt = convertToTimezone(localDtStr, localTzId);
+    expect(localDt.year()).toBe(2026);
+    expect(localDt.month()).toBe(7);
+    expect(localDt.date()).toBe(10);
+    expect(localDt.hour()).toBe(0);
+    expect(localDt.minute()).toBe(0);
+    expect(localDt.second()).toBe(0);
+  });
+
+  it('should have correct local datetime components when converting UTC datetime', () => {
+    const utcDtStr = '2026-08-10 22:00:00';
+    const utcDt = getUtcDatetime(utcDtStr);
+    const localTzId = TIMEZONE_IDS.PACIFIC;
+    const localConvertedDt = convertToTimezone(utcDt, localTzId);
+    
+    expect(utcDt.hour()).toBe(22);
+    expect(localConvertedDt.hour()).toBe(15);
+    expect(localConvertedDt.date()).toBe(utcDt.date());
+    expect(utcDt.diff(localConvertedDt)).toBe(0);
+  });
+});

--- a/src/helper/date.helper.ts
+++ b/src/helper/date.helper.ts
@@ -1,0 +1,51 @@
+import dayjs, { Dayjs } from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+import duration from 'dayjs/plugin/duration';
+import quarterOfYear from 'dayjs/plugin/quarterOfYear';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.extend(duration);
+dayjs.extend(quarterOfYear);
+
+export const TIMEZONE_IDS = {
+  PACIFIC: 'Canada/Pacific',
+};
+
+export const DATE_FORMATS = {
+  DATE_ONLY: 'YYYY-MM-DD',
+  DATETIME: 'YYYY-MM-DD HH:mm:ss',
+};
+
+/**
+ * Convert a datetime to a specified timezone.
+ * 
+ * @param datetime Datetime to be converted
+ * @param timezoneId Timezone identifier (eg. 'Canada/Pacific')
+ * @returns Dayjs object in the specified timezone
+ */
+export const convertToTimezone = (
+  datetime: string | Dayjs | Date,
+  timezoneId: string,
+) => {
+  return dayjs.tz(datetime, timezoneId);
+};
+
+/**
+ * Get UTC datetime.
+ * 
+ * @returns Dayjs object representing datetime in UTC
+ */
+export const getUtcDatetime = (datetime?: Dayjs | Date | string) => {
+  return dayjs.utc(datetime);
+};
+
+/**
+ * Get datetime representing the end of the quarter for a given datetime.
+ * @param datetime Datetime being used for reference
+ * @returns Dayjs object representing the end of the quarter for the inputted datetime
+ */
+export const getEndOfQuarter = (datetime: Dayjs) => {
+  return datetime.endOf('quarter');
+};

--- a/src/helper/facts.helper.ts
+++ b/src/helper/facts.helper.ts
@@ -1,5 +1,3 @@
-import dayjs from 'dayjs';
-import quarterOfYear from 'dayjs/plugin/quarterOfYear';
 import { Engine } from 'json-rules-engine';
 import { Policy } from 'onroute-policy-engine';
 import {
@@ -29,7 +27,12 @@ import {
   OVERLOAD_RATES_PER_10KM,
 } from '../constants/overload';
 
-dayjs.extend(quarterOfYear);
+import {
+  convertToTimezone,
+  getEndOfQuarter,
+  getUtcDatetime,
+  TIMEZONE_IDS,
+} from './date.helper';
 
 type AxleCalculationInputs = {
   vehicleConfiguration: Array<string>;
@@ -107,7 +110,14 @@ const getOverloadCost = (overloadKg: number, totalDistance: number) => {
  * @param engine json-rules-engine Engine instance to add facts to.
  */
 export function addRuntimeFacts(engine: Engine, policy: Policy): void {
-  const today: string = dayjs().format(PermitAppInfo.PermitDateFormat);
+  /**
+   * Add runtime fact for today's date (based on Pacific timezone)
+   */
+  const today: string = convertToTimezone(
+    getUtcDatetime(),
+    TIMEZONE_IDS.PACIFIC,
+  ).format(PermitAppInfo.PermitDateFormat);
+
   engine.addFact(PolicyFacts.ValidationDate, today);
 
   /**
@@ -123,7 +133,8 @@ export function addRuntimeFacts(engine: Engine, policy: Policy): void {
         {},
         PermitAppInfo.PermitStartDate,
       );
-      const dateFrom = dayjs(startDate, PermitAppInfo.PermitDateFormat);
+
+      const dateFrom = convertToTimezone(startDate, TIMEZONE_IDS.PACIFIC);
       const daysInPermitYear = dateFrom.add(1, 'year').diff(dateFrom, 'day');
       return daysInPermitYear;
     },
@@ -143,9 +154,8 @@ export function addRuntimeFacts(engine: Engine, policy: Policy): void {
         PermitAppInfo.PermitStartDate,
       );
 
-      const dateFrom = dayjs(startDate, PermitAppInfo.PermitDateFormat);
-      const endOfQuarter = dateFrom.endOf('quarter');
-
+      const dateFrom = convertToTimezone(startDate, TIMEZONE_IDS.PACIFIC);
+      const endOfQuarter = getEndOfQuarter(dateFrom);
       return endOfQuarter.format(PermitAppInfo.PermitDateFormat);
     },
   );
@@ -162,7 +172,7 @@ export function addRuntimeFacts(engine: Engine, policy: Policy): void {
       PermitAppInfo.PermitStartDate,
     );
 
-    const dateFrom = dayjs(startDate, PermitAppInfo.PermitDateFormat);
+    const dateFrom = convertToTimezone(startDate, TIMEZONE_IDS.PACIFIC);
     const endOfYear = dateFrom
       .endOf('year')
       .format(PermitAppInfo.PermitDateFormat);
@@ -378,13 +388,15 @@ export function addRuntimeFacts(engine: Engine, policy: Policy): void {
         {},
         params.dateFrom.path,
       );
+
       const dateToStr: string = await almanac.factValue(
         params.dateTo.fact,
         {},
         params.dateTo.path,
       );
-      const dateFrom = dayjs(dateFromStr, PermitAppInfo.PermitDateFormat);
-      const dateTo = dayjs(dateToStr, PermitAppInfo.PermitDateFormat);
+
+      const dateFrom = convertToTimezone(dateFromStr, TIMEZONE_IDS.PACIFIC);
+      const dateTo = convertToTimezone(dateToStr, TIMEZONE_IDS.PACIFIC);
       const daysBetween = dateTo.diff(dateFrom, 'day');
       return daysBetween;
     },

--- a/src/rule-operator/custom-operators.ts
+++ b/src/rule-operator/custom-operators.ts
@@ -10,6 +10,8 @@ import { Operator } from 'json-rules-engine';
 import { CustomOperator, PermitAppInfo } from 'onroute-policy-engine/enum';
 import dayjs from 'dayjs';
 
+import { convertToTimezone, TIMEZONE_IDS } from '../helper/date.helper';
+
 /**
  * Validates that the input is a string type
  * @param a - The value to validate
@@ -72,8 +74,8 @@ CustomOperators.push(
     CustomOperator.DateLessThan,
     (a: string, b: string) => {
       // Parse both dates using the permit application date format
-      const firstDate = dayjs(a, PermitAppInfo.PermitDateFormat.toString());
-      const secondDate = dayjs(b, PermitAppInfo.PermitDateFormat.toString());
+      const firstDate = convertToTimezone(a, TIMEZONE_IDS.PACIFIC);
+      const secondDate = convertToTimezone(b, TIMEZONE_IDS.PACIFIC);
 
       // Return true if first date is before second date (difference is negative)
       return firstDate.diff(secondDate) < 0;


### PR DESCRIPTION
- Add helper method to handle all dayjs initialization, and convert datetimes to Pacific timezone
- Replace all existing instances of dayjs usage with timezone conversion helper method
- Add and fix tests to use date helper methods